### PR TITLE
RFC: NodejsFunction

### DIFF
--- a/packages/resources/package.json
+++ b/packages/resources/package.json
@@ -85,6 +85,7 @@
     "@aws-cdk/assert": "1.132.0",
     "@types/cross-spawn": "^6.0.2",
     "@types/fs-extra": "^9.0.6",
+    "@types/lodash.clonedeep": "^4.5.6",
     "@types/node": "^14.0.27",
     "esbuild-runner": "^2.2.1"
   },

--- a/packages/resources/src/NodejsFunction.ts
+++ b/packages/resources/src/NodejsFunction.ts
@@ -1,0 +1,200 @@
+/* eslint-disable prefer-const */
+import { Runtime, Tracing } from "@aws-cdk/aws-lambda";
+import {
+  BundlingOptions,
+  NodejsFunction as CdkNodejsFunction,
+  NodejsFunctionProps as CdkNodejsFunctionProps,
+} from "@aws-cdk/aws-lambda-nodejs";
+import { Construct, Duration } from "@aws-cdk/core";
+import {
+  attachPermissionsToRole,
+  Function,
+  FunctionBundleObject,
+  FunctionProps,
+  Permissions,
+  PermissionType,
+  Stack,
+} from "@serverless-stack/resources";
+import { existsSync } from "fs";
+import path from "path";
+import cloneDeep from "lodash.clonedeep";
+import { Role } from "@aws-cdk/aws-iam";
+
+export interface NodejsFunctionProps extends CdkNodejsFunctionProps {
+  grantDatabaseAccess?: boolean;
+  handler?: string;
+  srcPath?: string;
+  permissions?: Permissions;
+}
+
+/**
+ * Compatibility layer between SST.Function and NodejsFunction
+ */
+export class NodejsFunction extends CdkNodejsFunction {
+  grantDatabaseAccess?: boolean;
+
+  constructor(scope: Construct, id: string, baseProps: NodejsFunctionProps) {
+    let { grantDatabaseAccess, handler, ...props } = baseProps;
+
+    const stack = Stack.of(scope) as Stack;
+    // merge props with default
+    stack.defaultFunctionProps
+      .slice()
+      .reverse()
+      .forEach((per) => {
+        props = NodejsFunction.mergeProps(per, props);
+      });
+    // Set defaults
+    let timeout = props.timeout || Duration.seconds(10);
+    const srcPath = Function.normalizeSrcPath(props.srcPath || ".");
+    const memorySize = props.memorySize || 1024;
+    const tracing = props.tracing || Tracing.ACTIVE;
+    const permissions = props.permissions;
+
+    // parse handler
+    let entry: string | undefined = undefined;
+    if (handler) {
+      // split on '.'
+      const origHandler = handler;
+      const lastDotIdx = origHandler.lastIndexOf(".");
+      entry = origHandler.substring(0, lastDotIdx);
+      handler = origHandler.substring(lastDotIdx + 1);
+
+      if (entry) {
+        // find extension
+        let entryPath = "";
+        const foundExt = [".ts", ".tsx", ".mjs", ".cjs", ".js", ".jsx"].find(
+          (ext) => {
+            entryPath = path.join(srcPath, entry + ext);
+            return existsSync(entryPath);
+          }
+        );
+        if (!foundExt) {
+          throw new Error(`Cannot find a handler file for "${entry}".`);
+        }
+        entry = path.join(srcPath, entry + foundExt);
+      }
+    }
+
+    // construct
+    const mergedProps = {
+      ...props,
+      handler,
+      entry,
+      tracing,
+      memorySize,
+      timeout,
+      bundling: {
+        ...props.bundling,
+        sourceMap: true,
+        sourcesContent: false,
+      },
+    };
+    super(scope, id, mergedProps);
+
+    // Attach permissions
+    if (permissions) {
+      this.attachPermissions(permissions);
+    }
+
+    // extra props to tag function with (should be refactored)
+    if (grantDatabaseAccess && !props.vpc)
+      throw new Error("vpc is requied if grantDatabaseAccess is true");
+    this.grantDatabaseAccess = grantDatabaseAccess;
+  }
+
+  static mergeProps(
+    baseProps?: FunctionProps,
+    props?: NodejsFunctionProps
+  ): NodejsFunctionProps {
+    // Merge environment
+    const environment = {
+      ...(baseProps?.environment || {}),
+      ...(props?.environment || {}),
+    };
+    const environmentProp =
+      Object.keys(environment).length === 0 ? {} : { environment };
+
+    // Merge layers
+    const layers = [...(baseProps?.layers || []), ...(props?.layers || [])];
+    const layersProp = layers.length === 0 ? {} : { layers };
+
+    // Merge permissions
+    let permissionsProp;
+    if (
+      baseProps?.permissions === PermissionType.ALL ||
+      props?.permissions === PermissionType.ALL
+    ) {
+      permissionsProp = { permissions: PermissionType.ALL };
+    } else {
+      const permissions = (baseProps?.permissions || []).concat(
+        props?.permissions || []
+      );
+      permissionsProp = permissions.length === 0 ? {} : { permissions };
+    }
+
+    // workaround for different FunctionProps.Runtime type, timeout
+    let { runtime, timeout, handler, bundle, ...base } = baseProps || {};
+    if (typeof timeout === "number") timeout = Duration.seconds(timeout);
+
+    // if (!handler) throw new Error("handler is not defined")
+    const baseNodejsProps: NodejsFunctionProps = {
+      ...base,
+      runtime: Runtime.NODEJS_14_X,
+      timeout,
+      handler,
+    };
+
+    // convert bundle to bundling
+    let bundling: BundlingOptions | undefined = {
+      ...(baseProps as NodejsFunctionProps).bundling,
+      ...props?.bundling,
+    };
+    if (typeof bundle === "object") {
+      const { copyFiles, ...bundleRest } = cloneDeep(
+        bundle
+      ) as FunctionBundleObject;
+      // TODO: copyfiles
+      // TODO: do typesafe conversion
+      bundling = { ...bundleRest, ...bundling } as any;
+    }
+
+    // copy schema.prisma by default
+    if (!bundling?.commandHooks)
+      bundling = {
+        ...bundling,
+        commandHooks: {
+          beforeInstall: () => [],
+          beforeBundling: () => [],
+          afterBundling: (inputDir: string, outputDir: string) => {
+            return [
+              `cp "${inputDir}/packages/repo/prisma/schema.prisma" "${outputDir}"`,
+            ];
+          },
+        },
+      };
+
+    return {
+      ...(baseNodejsProps || {}),
+      ...(props || {}),
+      ...layersProp,
+      ...environmentProp,
+      ...permissionsProp,
+      bundling,
+      // ...permissionsProp,
+    };
+  }
+
+  public attachPermissions(permissions: Permissions): void {
+    if (this.role) {
+      attachPermissionsToRole(this.role as Role, permissions);
+    }
+  }
+}
+
+export function addExtensionToHandler(
+  handler: string,
+  extension: string
+): string {
+  return handler.replace(/\.[\w\d]+$/, extension);
+}

--- a/packages/resources/src/NodejsFunction.ts
+++ b/packages/resources/src/NodejsFunction.ts
@@ -6,19 +6,17 @@ import {
   NodejsFunctionProps as CdkNodejsFunctionProps,
 } from "@aws-cdk/aws-lambda-nodejs";
 import { Construct, Duration } from "@aws-cdk/core";
-import {
-  attachPermissionsToRole,
-  Function,
-  FunctionBundleObject,
-  FunctionProps,
-  Permissions,
-  PermissionType,
-  Stack,
-} from "@serverless-stack/resources";
 import { existsSync } from "fs";
 import path from "path";
 import cloneDeep from "lodash.clonedeep";
 import { Role } from "@aws-cdk/aws-iam";
+import { Stack } from "./Stack";
+import { Function, FunctionBundleObject, FunctionProps } from "./Function";
+import {
+  attachPermissionsToRole,
+  PermissionType,
+  Permissions,
+} from "./util/permission";
 
 export interface NodejsFunctionProps extends CdkNodejsFunctionProps {
   grantDatabaseAccess?: boolean;
@@ -190,11 +188,4 @@ export class NodejsFunction extends CdkNodejsFunction {
       attachPermissionsToRole(this.role as Role, permissions);
     }
   }
-}
-
-export function addExtensionToHandler(
-  handler: string,
-  extension: string
-): string {
-  return handler.replace(/\.[\w\d]+$/, extension);
 }

--- a/packages/resources/src/NodejsScript.ts
+++ b/packages/resources/src/NodejsScript.ts
@@ -1,0 +1,31 @@
+/* eslint-disable @typescript-eslint/ban-types */
+/* eslint-disable prefer-const */
+import { Construct } from "@aws-cdk/core";
+import { Function } from "./Function";
+import { Script, ScriptProps } from "./Script";
+import { NodejsFunction, NodejsFunctionProps } from "./NodejsFunction";
+
+/**
+ * Compatibility layer between SST.Function and NodejsFunction
+ */
+export class NodejsScript extends Script {
+  constructor(scope: Construct, id: string, props: ScriptProps) {
+    let { ...rest } = props;
+
+    super(scope, id, rest);
+  }
+
+  override createUserFunction(type: string, fnDef?: any): Function | undefined {
+    if (!fnDef) {
+      return;
+    }
+    return fnDef as Function;
+
+    return new NodejsFunction(this, `${type}Function`, {
+      // timeout: 900,
+      // timeout: 20,
+      ...(this.props.defaultFunctionProps as any),
+      ...fnDef,
+    }) as Function;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5656,76 +5656,6 @@
     node-addon-api "3.2.1"
     node-gyp "8.1.0"
 
-"@serverless-stack/cli@^0.53.4":
-  version "0.53.4"
-  resolved "https://registry.yarnpkg.com/@serverless-stack/cli/-/cli-0.53.4.tgz#4369387dd15141969cc703757ef0f53ade2825fa"
-  integrity sha512-RZnOxxEZpn2m1ntVYXV1x67NAz8R0B04oFzFSB58/8zRbqgnz4aghbnvCQVyF3NwSsQrASdgjEm7RB746ACesw==
-  dependencies:
-    "@aws-cdk/aws-apigatewayv2" "1.132.0"
-    "@aws-cdk/aws-dynamodb" "1.132.0"
-    "@aws-cdk/aws-iam" "1.132.0"
-    "@aws-cdk/aws-lambda" "1.132.0"
-    "@aws-cdk/core" "1.132.0"
-    "@babel/core" "^7.10.5"
-    "@babel/eslint-parser" "^7.11.3"
-    "@babel/eslint-plugin" "^7.11.3"
-    "@babel/plugin-proposal-class-properties" "^7.10.4"
-    "@babel/preset-env" "^7.10.4"
-    "@serverless-stack/aws-lambda-ric" "^2.0.8"
-    "@serverless-stack/core" "^0.53.4"
-    "@serverless-stack/resources" "^0.53.4"
-    "@types/jest" "^27.0.2"
-    "@types/node" "^14.0.27"
-    "@typescript-eslint/eslint-plugin" "^4.15.1"
-    "@typescript-eslint/parser" "^4.15.1"
-    apollo-server-express "^2.25.2"
-    aws-cdk "1.132.0"
-    aws-sdk "^2.761.0"
-    body-parser "^1.19.0"
-    chalk "^4.1.0"
-    chokidar "^3.4.3"
-    core-js "^3.6.5"
-    cross-spawn "^7.0.3"
-    detect-port-alt "^1.1.6"
-    esbuild "^0.12.20"
-    esbuild-runner "^2.2.1"
-    eslint "^7.16.0"
-    eslint-config-serverless-stack "^0.53.4"
-    express "^4.17.1"
-    fast-safe-stringify "^2.0.6"
-    fs-extra "^9.0.1"
-    graphql "^15.5.1"
-    is-root "^2.1.0"
-    jest "^27.3.1"
-    node-fetch "^2.6.1"
-    open "^8.4.0"
-    promise.allsettled "^1.0.2"
-    prompts "^2.4.1"
-    source-map-support "^0.5.19"
-    ts-jest "^26.1.4"
-    typescript "^4.4.3"
-    ws "^7.4.0"
-    yargs "^15.4.1"
-
-"@serverless-stack/core@^0.53.4":
-  version "0.53.4"
-  resolved "https://registry.yarnpkg.com/@serverless-stack/core/-/core-0.53.4.tgz#e51b0d8e71d703eb86968dd07c47eb4f389e7359"
-  integrity sha512-FE0DF5fI6fV10Lr39zgC+GtdYq+MDvIomoR/dEw/5liFG/pWfBWtnG5k/smtsg0UYXW2BROAFfD9IACWkhk0nQ==
-  dependencies:
-    aws-cdk "1.132.0"
-    aws-sdk "^2.761.0"
-    chalk "^4.1.0"
-    cross-spawn "^7.0.3"
-    dotenv "^10.0.0"
-    dotenv-expand "^5.1.0"
-    express "^4.17.1"
-    fs-extra "^9.0.1"
-    js-yaml "^4.1.0"
-    log4js "^6.3.0"
-    stun "^2.1.0"
-    typescript "^4.4.3"
-    uuid "^8.3.2"
-
 "@serverless-stack/nextjs-core@^0.1.9":
   version "0.1.9"
   resolved "https://registry.yarnpkg.com/@serverless-stack/nextjs-core/-/nextjs-core-0.1.9.tgz#ca480e8081df5d262ed5f61ef44584e130198e17"
@@ -5758,74 +5688,6 @@
     normalize-path "^3.0.0"
     path-to-regexp "^6.1.0"
     send "^0.17.1"
-
-"@serverless-stack/resources@^0.53.4":
-  version "0.53.4"
-  resolved "https://registry.yarnpkg.com/@serverless-stack/resources/-/resources-0.53.4.tgz#0ef9d7296c76622f88773f81ac89d7bfcb96a490"
-  integrity sha512-X1gIuuUbgQlVJNklXMvCIZOUhaPqnarxIxlG9PxPcq4urDC3FQFnc2Emhf2OPT2vgy61z4DVOxlE2Ik58rWHtQ==
-  dependencies:
-    "@aws-cdk/aws-apigateway" "1.132.0"
-    "@aws-cdk/aws-apigatewayv2" "1.132.0"
-    "@aws-cdk/aws-apigatewayv2-authorizers" "1.132.0"
-    "@aws-cdk/aws-apigatewayv2-integrations" "1.132.0"
-    "@aws-cdk/aws-appsync" "1.132.0"
-    "@aws-cdk/aws-autoscaling" "1.132.0"
-    "@aws-cdk/aws-certificatemanager" "1.132.0"
-    "@aws-cdk/aws-cloudfront" "1.132.0"
-    "@aws-cdk/aws-cloudfront-origins" "1.132.0"
-    "@aws-cdk/aws-cognito" "1.132.0"
-    "@aws-cdk/aws-dynamodb" "1.132.0"
-    "@aws-cdk/aws-ec2" "1.132.0"
-    "@aws-cdk/aws-elasticloadbalancingv2" "1.132.0"
-    "@aws-cdk/aws-events" "1.132.0"
-    "@aws-cdk/aws-events-targets" "1.132.0"
-    "@aws-cdk/aws-iam" "1.132.0"
-    "@aws-cdk/aws-kinesis" "1.132.0"
-    "@aws-cdk/aws-lambda" "1.132.0"
-    "@aws-cdk/aws-lambda-event-sources" "1.132.0"
-    "@aws-cdk/aws-lambda-nodejs" "1.132.0"
-    "@aws-cdk/aws-logs" "1.132.0"
-    "@aws-cdk/aws-rds" "1.132.0"
-    "@aws-cdk/aws-route53" "1.132.0"
-    "@aws-cdk/aws-route53-patterns" "1.132.0"
-    "@aws-cdk/aws-route53-targets" "1.132.0"
-    "@aws-cdk/aws-s3" "1.132.0"
-    "@aws-cdk/aws-s3-assets" "1.132.0"
-    "@aws-cdk/aws-s3-notifications" "1.132.0"
-    "@aws-cdk/aws-secretsmanager" "1.132.0"
-    "@aws-cdk/aws-sns" "1.132.0"
-    "@aws-cdk/aws-sns-subscriptions" "1.132.0"
-    "@aws-cdk/aws-sqs" "1.132.0"
-    "@aws-cdk/aws-ssm" "1.132.0"
-    "@aws-cdk/core" "1.132.0"
-    "@aws-cdk/cx-api" "1.132.0"
-    "@aws-cdk/lambda-layer-awscli" "1.132.0"
-    "@graphql-tools/load-files" "^6.3.2"
-    "@graphql-tools/merge" "^6.2.14"
-    "@serverless-stack/core" "^0.53.4"
-    "@serverless-stack/nextjs-lambda" "^0.1.9"
-    "@types/jest" "^26.0.7"
-    archiver "^5.3.0"
-    chalk "^4.1.0"
-    cross-spawn "^7.0.3"
-    esbuild "^0.12.20"
-    eslint "^7.16.0"
-    fs-extra "^9.0.1"
-    glob "^7.1.7"
-    graphql "^15.5.1"
-    jest "^26.1.0"
-    ts-jest "^26.1.4"
-    typescript "^4.4.3"
-    zip-local "^0.3.4"
-
-"@serverless-stack/static-site-env@^0.53.4":
-  version "0.53.4"
-  resolved "https://registry.yarnpkg.com/@serverless-stack/static-site-env/-/static-site-env-0.53.4.tgz#400bdb7f5974e6b62b81cbd35a5d9fdb0b495031"
-  integrity sha512-+I5C1fkhrFgvbBR0v8LPRMq9U6qQkrEr5nuYni8VWGF8WG4a1QiHNMxyrNNFD5BDbE049B3/xw6Zb2GmerFQMA==
-  dependencies:
-    "@serverless-stack/core" "^0.53.4"
-    chalk "^4.1.0"
-    yargs "^15.4.1"
 
 "@sinonjs/commons@^1.7.0":
   version "1.8.3"
@@ -7097,6 +6959,18 @@
     "@types/keygrip" "*"
     "@types/koa-compose" "*"
     "@types/node" "*"
+
+"@types/lodash.clonedeep@^4.5.6":
+  version "4.5.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.6.tgz#3b6c40a0affe0799a2ce823b440a6cf33571d32b"
+  integrity sha512-cE1jYr2dEg1wBImvXlNtp0xDoS79rfEdGozQVgliDZj1uERH4k+rmEMTudP9b4VQ8O6nRb5gPqft0QzEQGMQgA==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.14.178"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.178.tgz#341f6d2247db528d4a13ddbb374bcdc80406f4f8"
+  integrity sha512-0d5Wd09ItQWH1qFbEyQ7oTQ3GZrMfth5JkbN3EvTKLXcHLRDSXeLnlvlOn0wvxVIwK5o2M8JzP/OWz7T3NRsbw==
 
 "@types/long@^4.0.0":
   version "4.0.1"
@@ -11972,18 +11846,6 @@ eslint-config-react-app@^6.0.0:
   integrity sha512-bpoAAC+YRfzq0dsTk+6v9aHm/uqnDwayNAXleMypGl6CpxI9oXXscVHo4fk3eJPIn+rsbtNetB4r/ZIidFIE8A==
   dependencies:
     confusing-browser-globals "^1.0.10"
-
-eslint-config-serverless-stack@^0.53.4:
-  version "0.53.4"
-  resolved "https://registry.yarnpkg.com/eslint-config-serverless-stack/-/eslint-config-serverless-stack-0.53.4.tgz#d730ac7d2963ba2e16e7e1edb1eb0b46ef54d2a2"
-  integrity sha512-xd/INUE7uNXDLhhnN5tQqZClbsphMa8LIQidUzV6p9PxAtSe+rBLzU3MMBBAGzafwz/sb6/6dHmmLE17OowBAQ==
-  dependencies:
-    "@babel/eslint-parser" "^7.11.3"
-    "@babel/plugin-proposal-class-properties" "^7.10.4"
-    "@babel/preset-env" "^7.10.4"
-    "@typescript-eslint/eslint-plugin" "^4.15.1"
-    "@typescript-eslint/parser" "^4.15.1"
-    eslint "^7.16.0"
 
 eslint-import-resolver-node@^0.3.6:
   version "0.3.6"


### PR DESCRIPTION
Following up on #1113 -

I like NodejsFunction from AWS because it's from AWS and does almost everything I want, except for keeping track of default function options...

It has a lot of bundling options like fine-grained source map control, every esbuild option supported, custom hashing, unobtrusive builds that don't generate scripts to run inside my packages (which causes issues like #1154 for me), and it's semi-supported by the official AWS CDK team.

I created a NodejsFunction construct that I'm using to help migrate my existing application to SST. Maybe it's possible to refactor it with Function and give SST users their choice of construct while using the lovely function defaults that SST provides. I'm opening this PR to get some feedback on this idea.