### PR TITLE
Fix: docs CDK v1 -> v2

### DIFF
--- a/www/docs/advanced/extending-sst.md
+++ b/www/docs/advanced/extending-sst.md
@@ -14,7 +14,7 @@ All CDK constructs and CloudFormation resources are supported in SST apps.
 Here is an example of creating a VPC using the CDK construct, and then using the VPC inside the [`Api`](../constructs/Api.md) construct.
 
 ```ts
-import { Vpc } from "@aws-cdk/aws-ec2";
+import { Vpc } from "aws-cdk-lib/aws-ec2";
 import { Api, StackContext } from "@serverless-stack/resources";
 
 function Stack({ stack }: StackContext) {


### PR DESCRIPTION
The documentation referenced CDK v1, which is no longer used.
This commit fixes the documentation to reference CDK v2, as is actually the case.