### PR TITLE
Allow specifying ESM/CJS compat shim contents

### DIFF
--- a/packages/resources/src/Function.ts
+++ b/packages/resources/src/Function.ts
@@ -270,7 +270,7 @@ export interface FunctionProps
    *   url: true
    * })
    * ```
-   * 
+   *
    * ```js
    * new Function(stack, "Function", {
    *   handler: "src/function.handler",
@@ -505,6 +505,12 @@ export interface FunctionBundleNodejsProps extends FunctionBundleBase {
      * ```
      */
     plugins?: string;
+    /**
+     * Custom hook to inject into ESM bundles for CJS compatability.
+     *
+     * @see https://github.com/evanw/esbuild/pull/2067
+     */
+    cjsCompatShim?: string;
   };
   /**
    * Enable or disable minification

--- a/yarn.lock
+++ b/yarn.lock
@@ -16124,9 +16124,9 @@ vfile@^4.0.0:
     unist-util-stringify-position "^2.0.0"
     vfile-message "^2.0.0"
 
-vite-plugin-sentry@^1.0.14:
+vite-plugin-sentry@1.0.14:
   version "1.0.14"
-  resolved "https://registry.npmjs.org/vite-plugin-sentry/-/vite-plugin-sentry-1.0.14.tgz"
+  resolved "https://registry.yarnpkg.com/vite-plugin-sentry/-/vite-plugin-sentry-1.0.14.tgz#2b66723015e0d586573b37d2be69844d9ed648d9"
   integrity sha512-G/nhHtzxATcWujCvC8gTrrDH+Ryq9tcTijwKySplBGGD6DBP+nwvvTPxPQ0e6lRVdMbJ1R4mYXa191t3mvDwww==
   dependencies:
     "@sentry/cli" "1.74.2"


### PR DESCRIPTION
This is related to my issue here: https://discord.com/channels/983865673656705025/996271841897349132

It's not really a solution because I don't want to have to essentially hardcore `__dirname` to `/var/task` but this is blocking me now and others may have a similar need for more robust/custom shims.

---

My issue is that SST doesn't put the bundle at the top level and prisma tries to look in `__dirname` for the `schema.prisma` file.

> ideally i could either choose to use a flat bundle structure or have a way to copy a file into the same dir as the output bundle 