### PR TITLE
Update Cron construct documentation

### DIFF
--- a/www/docs/constructs/Cron.md
+++ b/www/docs/constructs/Cron.md
@@ -60,7 +60,7 @@ Disable the cron job from automatically running while developing.
 new Cron(stack, "Cron", {
   schedule: "rate(1 minute)",
   job: "src/lambda.main",
-  enabled: app.local,
+  enabled: !app.local,
 });
 ```
 


### PR DESCRIPTION
As far as I can tell, it should be `enabled: !app.local` if you want to "[d]isable the cron job from automatically running while developing" ? Otherwise it's only enabled if running locally.