### PR TITLE
Fix typo in example documentation

### DIFF
--- a/packages/resources/src/Table.ts
+++ b/packages/resources/src/Table.ts
@@ -159,7 +159,7 @@ export interface TableProps {
    *     sk: "string",
    *     lsi1sk: "string",
    *   },
-   *   globalIndexes: {
+   *   localIndexes: {
    *     "lsi1": { sortKey: "lsi1sk" },
    *   },
    * });


### PR DESCRIPTION
Change the example documentation for `localIndexes` to use `localIndexes` instead of `globalIndexes`.