### PR TITLE
Function: allow using @ edge

### DIFF
--- a/packages/resources/src/Function.ts
+++ b/packages/resources/src/Function.ts
@@ -960,8 +960,8 @@ export class Function extends lambda.Function implements SSTConstruct {
     const { config } = this.props;
 
     // Add environment variables
-    this.addEnvironment("SST_APP", app.name);
-    this.addEnvironment("SST_STAGE", app.stage);
+    this.addEnvironment("SST_APP", app.name, { removeInEdge: true });
+    this.addEnvironment("SST_STAGE", app.stage, { removeInEdge: true });
     (config || []).forEach((c) => {
       if (c instanceof Secret) {
         this.addEnvironment(`${FunctionConfig.SECRET_ENV_PREFIX}${c.name}`, "1");


### PR DESCRIPTION
[If the stack is in `us-east-1`, a "normal" `lambda.Function` can be used instead of an `EdgeFunction`](https://docs.aws.amazon.com/cdk/api/v1/docs/aws-cloudfront-readme.html#lambdaedge).

However, the SST Function construct sets some environment variables, which [are not supported @ edge](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/edge-functions-restrictions.html#lambda-at-edge-runtime-restrictions).

Enabling the `removeInEdge` option for these environment variables solves the problem