### PR TITLE
Stack: use root.account instead of CDK_DEFAULT_ACCOUNT environment variable

### DIFF
--- a/.changeset/neat-queens-judge.md
+++ b/.changeset/neat-queens-judge.md
@@ -1,0 +1,5 @@
+---
+"@serverless-stack/resources": patch
+---
+
+Stack: use root.account instead of CDK_DEFAULT_ACCOUNT environment variable

--- a/packages/resources/src/Stack.ts
+++ b/packages/resources/src/Stack.ts
@@ -49,7 +49,7 @@ export class Stack extends cdk.Stack {
     super(scope, stackId, {
       ...props,
       env: {
-        account: process.env.CDK_DEFAULT_ACCOUNT,
+        account: root.account,
         region: root.region,
       },
     });


### PR DESCRIPTION
Closes #1930 