### PR TITLE
docs: updated queue docs to specify the cdk queue vs sst queue

### DIFF
--- a/www/docs/constructs/Queue.about.md
+++ b/www/docs/constructs/Queue.about.md
@@ -108,12 +108,13 @@ new Queue(stack, "Queue", {
 Override the internally created CDK `Queue` instance.
 
 ```js {6}
-import { Queue } from "aws-cdk-lib/aws-sqs";
+import { Queue } from "@serverless-stack/resources";
+import { Queue as CdkQueue } from 'aws-cdk-lib/aws-sqs';
 
 new Queue(stack, "Queue", {
   consumer: "src/queueConsumer.main",
   cdk: {
-    queue: Queue.fromQueueArn(this, "MySqsQueue", queueArn),
+    queue: CdkQueue.fromQueueArn(stack, "MySqsQueue", queueArn),
   },
 });
 ```

--- a/www/docs/constructs/Queue.about.md
+++ b/www/docs/constructs/Queue.about.md
@@ -23,7 +23,7 @@ Create an _empty_ queue and lazily add the consumer.
 ```js {3}
 const queue = new Queue(stack, "Queue");
 
-queue.addConsumer(this, "src/queueConsumer.main");
+queue.addConsumer(stack, "src/queueConsumer.main");
 ```
 
 #### Configuring the consumer function
@@ -108,13 +108,12 @@ new Queue(stack, "Queue", {
 Override the internally created CDK `Queue` instance.
 
 ```js {6}
-import { Queue } from "@serverless-stack/resources";
-import { Queue as CdkQueue } from "aws-cdk-lib/aws-sqs";
+import * as sqs from "aws-cdk-lib/aws-sqs";
 
 new Queue(stack, "Queue", {
   consumer: "src/queueConsumer.main",
   cdk: {
-    queue: CdkQueue.fromQueueArn(stack, "MySqsQueue", queueArn),
+    queue: sqs.Queue.fromQueueArn(stack, "MySqsQueue", queueArn),
   },
 });
 ```

--- a/www/docs/constructs/Queue.about.md
+++ b/www/docs/constructs/Queue.about.md
@@ -109,7 +109,7 @@ Override the internally created CDK `Queue` instance.
 
 ```js {6}
 import { Queue } from "@serverless-stack/resources";
-import { Queue as CdkQueue } from 'aws-cdk-lib/aws-sqs';
+import { Queue as CdkQueue } from "aws-cdk-lib/aws-sqs";
 
 new Queue(stack, "Queue", {
   consumer: "src/queueConsumer.main",


### PR DESCRIPTION
There are two imports of `Queue` that happens and the docs made it seem like it should both be coming from the main AWS CDK instead of separating the imports.