### PR TITLE
fix: Remove single quotes to avoid JSON parse error

### DIFF
--- a/packages/core/src/bootstrap/index.ts
+++ b/packages/core/src/bootstrap/index.ts
@@ -96,7 +96,7 @@ async function deployStack(config: any, cliInfo: any, tags: Record<string, strin
       "node",
       "bin/index.mjs",
       region,
-      `'${JSON.stringify(tags)}'`,
+      `${JSON.stringify(tags)}`,
     ].join(" "),
     output: "cdk.out",
   };


### PR DESCRIPTION
When a new minimal SST project is created, and run `npm start`, it throws the following error:

```
'{}'
^

SyntaxError: Unexpected token ' in JSON at position 0
```

Removed single quotes from caller to avoid JSON parse error.