### PR TITLE
Docs: Parameter and Secret SSM name

### DIFF
--- a/www/docs/advanced/testing.md
+++ b/www/docs/advanced/testing.md
@@ -67,15 +67,15 @@ Behind the scene, the `sst load-config` command fetches all the Config values, [
 The following environment variables are set.
 - `SST_APP` with the name of your SST app
 - `SST_STAGE` with the stage
-- For Secrets, `load-config` fetches and decryptes all SSM Parameters prefixed with `/aws/{appName}/{stageName}/secrets/*` and `/aws/{appName}/.fallback/secrets/*`, and sets corresponding environment varaibles `SST_PARAM_*`.
+- For Secrets, `load-config` fetches and decryptes all SSM Parameters prefixed with `/sst/{appName}/{stageName}/secrets/*` and `/sst/{appName}/.fallback/secrets/*`, and sets corresponding environment varaibles `SST_PARAM_*`.
 
-  ie. `SST_PARAM_STRIPE_KEY` is creatd with value from `/aws/{appName}/{stageName}/secrets/STRIPE_KEY`
-- For Parameters, `load-config` fetches all SSM Parameters prefixed with `/aws/{appName}/{stageName}/parameters/*`, and sets corresponding environment varaibles `SST_PARAM_*`.
+  ie. `SST_PARAM_STRIPE_KEY` is creatd with value from `/sst/{appName}/{stageName}/secrets/STRIPE_KEY`
+- For Parameters, `load-config` fetches all SSM Parameters prefixed with `/sst/{appName}/{stageName}/parameters/*`, and sets corresponding environment varaibles `SST_PARAM_*`.
 
-  ie. `SST_PARAM_USER_UPDATED_TOPIC` is created with value from `/aws/{appName}/{stageName}/parameters/USER_UPDATED_TOPIC`
+  ie. `SST_PARAM_USER_UPDATED_TOPIC` is created with value from `/sst/{appName}/{stageName}/parameters/USER_UPDATED_TOPIC`
 
   :::note
-  Secret values ie. `/aws/{appName}/{stageName}/secrets/STRIPE_KEY` are stored as Parameter environment variables `SST_PARAM_STRIPE_KEY`. This is intentional so the [`@serverless-stack/node/config`](packages/node.md#config) helper library doesn't need to re-fetch the secret values at runtime.
+  Secret values ie. `/sst/{appName}/{stageName}/secrets/STRIPE_KEY` are stored as Parameter environment variables `SST_PARAM_STRIPE_KEY`. This is intentional so the [`@serverless-stack/node/config`](packages/node.md#config) helper library doesn't need to re-fetch the secret values at runtime.
   :::
 
 ## Integration tests

--- a/www/docs/advanced/testing.md
+++ b/www/docs/advanced/testing.md
@@ -67,10 +67,10 @@ Behind the scene, the `sst load-config` command fetches all the Config values, [
 The following environment variables are set.
 - `SST_APP` with the name of your SST app
 - `SST_STAGE` with the stage
-- For Secrets, `load-config` fetches and decryptes all SSM Parameters prefixed with `/sst/{appName}/{stageName}/secrets/*` and `/sst/{appName}/.fallback/secrets/*`, and sets corresponding environment varaibles `SST_PARAM_*`.
+- For Secrets, `load-config` fetches and decrypts all SSM Parameters prefixed with `/sst/{appName}/{stageName}/secrets/*` and `/sst/{appName}/.fallback/secrets/*`, and sets corresponding environment variables `SST_PARAM_*`.
 
-  ie. `SST_PARAM_STRIPE_KEY` is creatd with value from `/sst/{appName}/{stageName}/secrets/STRIPE_KEY`
-- For Parameters, `load-config` fetches all SSM Parameters prefixed with `/sst/{appName}/{stageName}/parameters/*`, and sets corresponding environment varaibles `SST_PARAM_*`.
+  ie. `SST_PARAM_STRIPE_KEY` is created with value from `/sst/{appName}/{stageName}/secrets/STRIPE_KEY`
+- For Parameters, `load-config` fetches all SSM Parameters prefixed with `/sst/{appName}/{stageName}/parameters/*`, and sets corresponding environment variables `SST_PARAM_*`.
 
   ie. `SST_PARAM_USER_UPDATED_TOPIC` is created with value from `/sst/{appName}/{stageName}/parameters/USER_UPDATED_TOPIC`
 

--- a/www/docs/environment-variables.md
+++ b/www/docs/environment-variables.md
@@ -101,7 +101,7 @@ import { Config } from "@serverless-stack/node/config";
 
 The module reads the value from `process.env.SST_PARAM_USER_UPDATED_TOPIC` and assigns it to `Config.USER_UPDATED_TOPIC`. You can then reference `Config.USER_UPDATED_TOPIC` directly in your code.
 
-SST also stores a copy of the parameter values in [AWS SSM](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html). For each parameter, an SSM parameter of the type `String` is created with the name `/aws/{appName}/{stageName}/parameters/USER_UPDATED_TOPIC`, where `{appName}` is the name of your SST app, and `{stageName}` is the stage. The parameter value in this case is the topic name stored in plain text.
+SST also stores a copy of the parameter values in [AWS SSM](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html). For each parameter, an SSM parameter of the type `String` is created with the name `/sst/{appName}/{stageName}/parameters/USER_UPDATED_TOPIC`, where `{appName}` is the name of your SST app, and `{stageName}` is the stage. The parameter value in this case is the topic name stored in plain text.
 
 Storing the parameter values in SSM might seem redundant. But it provides a convenient way to fetch all the parameters used in your application. This can be extremely useful for testing. This isn't possible when using Lambda environment variables and we are going to see why in the next section.
 
@@ -151,7 +151,7 @@ export const handler = async () => {
 
 What should the `TOPIC_NAME` be in your tests?
 
-With `Config`, the value for each Parameter is stored in SSM. When running tests, you can easily look up the values by fetching all SSM Parameters prefixed with `/aws/{appName}/{stageName}/parameters/*`.
+With `Config`, the value for each Parameter is stored in SSM. When running tests, you can easily look up the values by fetching all SSM Parameters prefixed with `/sst/{appName}/{stageName}/parameters/*`.
 
 Since `Config` enforces Parameter values to be the same for all functions using them, you would not run into this issue.
 
@@ -239,7 +239,7 @@ When you run:
 npx sst secrets set STRIPE_KEY sk_test_abc123
 ```
 
-An SSM parameter of the type `SecureString` is created with the name `/aws/{appName}/{stageName}/secrets/STRIPE_KEY`, where `{appName}` is the name of your SST app, and `{stageName}` is the stage you are configuring for. The parameter value `sk_test_abc123` gets encrypted and stored in AWS SSM.
+An SSM parameter of the type `SecureString` is created with the name `/sst/{appName}/{stageName}/secrets/STRIPE_KEY`, where `{appName}` is the name of your SST app, and `{stageName}` is the stage you are configuring for. The parameter value `sk_test_abc123` gets encrypted and stored in AWS SSM.
 
 And when you pass secrets into a function:
 
@@ -304,7 +304,7 @@ To set a fallback value for `STRIPE_KEY`, run:
 npx sst secrets set-fallback STRIPE_KEY sk_test_abc123
 ```
 
-Similar to the `set` command, SST creates an AWS SSM Parameter of the type `SecureString`. And the parameter name in this case is `/aws/{appName}/.fallback/secrets/STRIPE_KEY`.
+Similar to the `set` command, SST creates an AWS SSM Parameter of the type `SecureString`. And the parameter name in this case is `/sst/{appName}/.fallback/secrets/STRIPE_KEY`.
 
 :::note
 The fallback value can only be inherited by stages deployed in the same AWS account and region.

--- a/www/docs/packages/node.md
+++ b/www/docs/packages/node.md
@@ -32,7 +32,7 @@ export const handler = async () => {
 
 When you import `@serverless-stack/node/config`, it does two things:
 
-- For Secrets, `Config` performs a top-level await to fetch and decrypt the secrets values from SSM ie. `/aws/{appName}/{stageName}/secrets/STRIPE_KEY`. Once fetched, you can reference `Config.STRIPE_KEY` directly in your code.
+- For Secrets, `Config` performs a top-level await to fetch and decrypt the secrets values from SSM ie. `/sst/{appName}/{stageName}/secrets/STRIPE_KEY`. Once fetched, you can reference `Config.STRIPE_KEY` directly in your code.
 - For Parameters, `Config` reads the parameter values from Lambda environment variables, ie. `process.env.SST_PARAM_USER_UPDATED_TOPIC` and assigns to `Config.USER_UPDATED_TOPIC`.
 
 Read more about how Config works in the chapter on [Environment variables](../environment-variables.md).


### PR DESCRIPTION
The docs specified that the generated SSM names are prefixed with `/aws/`, while in fact the generated names are prefixed with `/sst/`.

https://github.com/serverless-stack/sst/blob/0bc3ef4cd10977c13ec3856742a75133d0e6722f/packages/core/src/function-config/index.ts#L142-L144
https://github.com/serverless-stack/sst/blob/0bc3ef4cd10977c13ec3856742a75133d0e6722f/packages/core/src/function-config/index.ts#L150-L152

Also fixed some typos.