### PR TITLE
Feat: add parameters option to cli

### DIFF
--- a/packages/cli/bin/scripts.mjs
+++ b/packages/cli/bin/scripts.mjs
@@ -58,6 +58,7 @@ const cmd = {
   addCdk: "add-cdk",
   update: "update",
   secrets: "secrets",
+  parameters: "parameters",
   bootstrap: "bootstrap",
   telemetry: "telemetry",
   loadConfig: "load-config",
@@ -192,6 +193,69 @@ const argv = yargs
           [
             `$0 ${cmd.secrets} remove-fallback STRIPE_KEY3`,
             "Remove the fallback for a secret"
+          ],
+        ]);
+
+    }
+  )
+  .command(
+    `${cmd.parameters} [action] [name] [value]`,
+    "Manage app parameters",
+    (yargs) => {
+      addOptions(cmd.parameters)(yargs);
+      return yargs
+        .positional("action", {
+          type: "string",
+          choices: ["list", "get", "set", "remove", "set-fallback", "remove-fallback"],
+          description: "Action to perform",
+        })
+        .positional("name", {
+          type: "string",
+          description: "Name of the parameter",
+        })
+        .positional("value", {
+          type: "string",
+          description: "Value of the parameter",
+        })
+        .option("format", {
+          type: "string",
+          choices: ["env"],
+          describe: "Output the parameter values in the .env format. Only apply to the 'list' action.",
+        })
+        .check((argv) => {
+          const action = argv["action"];
+          if (["get", "remove", "remove-fallback"].includes(action) && !argv.name) {
+            throw new Error("Please specify a parameter name");
+          }
+          if (["set", "set-fallback"].includes(action) && (!argv.name || !argv.value)) {
+            throw new Error("Please specify a parameter name and value");
+          }
+          return true;
+        })
+        .example([
+          [
+            `$0 ${cmd.parameters} list`,
+            "Fetch and decrypt all parameters"
+          ],
+          [
+            `$0 ${cmd.parameters} get STRIPE_KEY`,
+            "Fetch and decrypt a parameter"
+          ],
+          [
+            `$0 ${cmd.parameters} set STRIPE_KEY sk_test_123`,
+            "Encrypt and update a parameter"
+          ],
+          [
+            `$0 ${cmd.parameters} remove STRIPE_KEY`,
+            "Remove a parameter"
+          ],
+          [
+            `$0 ${cmd.parameters} set-fallback STRIPE_KEY sk_test_123`,
+            "Encrypt and update the fallback for a parameter"
+          ],
+          [
+            `$0 ${cmd.parameters} remove-fallback STRIPE_KEY3`,
+            "Remove the fallback for a parameter"
           ],
         ]);
 
@@ -352,6 +416,7 @@ async function run() {
     [cmd.remove]: await import("../scripts/remove.mjs"),
     [cmd.console]: await import("../scripts/console.mjs"),
     [cmd.secrets]: await import("../scripts/secrets.mjs"),
+    [cmd.parameters]: await import("../scripts/parameters.mjs"),
     [cmd.addCdk]: await import("../scripts/add-cdk.mjs"),
     [cmd.bootstrap]: await import("../scripts/bootstrap.mjs"),
     [cmd.loadConfig]: await import("../scripts/load-config.mjs"),
@@ -378,6 +443,7 @@ async function run() {
     case cmd.addCdk:
     case cmd.console:
     case cmd.secrets:
+    case cmd.parameters:
     case cmd.bootstrap:
     case cmd.loadConfig: {
       if (script === cmd.start

--- a/packages/cli/scripts/parameters.mjs
+++ b/packages/cli/scripts/parameters.mjs
@@ -1,0 +1,95 @@
+import chalk from "chalk";
+import {
+  getChildLogger,
+  FunctionConfig,
+} from "@serverless-stack/core";
+
+const logger = getChildLogger("client");
+
+export default async function (argv, config) {
+  const { name: app, stage, region } = config;
+  const { action } = argv;
+
+  logger.info("");
+
+  if (action === "list") {
+    await handleList(argv, app, stage, region);
+  } else if (action === "get") {
+    await handleGet(argv, app, stage, region);
+  } else if (action === "set") {
+    await handleSet(argv, app, stage, region);
+  } else if (action === "remove") {
+    await handleRemove(argv, app, stage, region);
+  }
+
+  logger.info("");
+}
+
+async function handleList(argv, app, stage, region) {
+  const parameters = await FunctionConfig.listParameters(app, stage, region);
+  const keys = Object.keys(parameters);
+
+  if (keys.length === 0) {
+    logger.info(`No parameters found for the ${stage} stage.`);
+  }
+  else if (argv.format === "env") {
+    printParametersInEnvFormat(parameters);
+  }
+  else {
+    printParametersInTableFormat(parameters);
+  }
+}
+
+async function handleGet(argv, app, stage, region) {
+  const { name } = argv;
+  const parameter = await FunctionConfig.getParameter(app, stage, region, name);
+  if (parameter) {
+    logger.info(chalk.bold(parameter));
+  } else {
+    logger.info(`${name} is not set. To set it, run`);
+    logger.info("");
+    logger.info(chalk.bold(`  sst parameters set ${name} <value>`));
+  }
+}
+
+async function handleSet(argv, app, stage, region) {
+  const { name, value } = argv;
+  await FunctionConfig.setParameter(app, stage, region, name, value);
+  logger.info("\n✅ Updated");
+}
+
+async function handleRemove(argv, app, stage, region) {
+  const { name } = argv;
+  await FunctionConfig.removeParameter(app, stage, region, name);
+  logger.info("\n✅ Removed");
+}
+
+function printParametersInEnvFormat(secrets) {
+  const keys = Object.keys(secrets);
+  keys.sort().forEach((key) => {
+    logger.info(`${key}=${secrets[key].value || secrets[key].fallbackValue}`);
+  });
+}
+
+function printParametersInTableFormat(parameters) {
+  console.log(parameters);
+  const keys = Object.keys(parameters);
+  const keyLen = Math.max(
+    "Parameters".length,
+    ...keys.map((key) => key.length),
+  );
+  const valueLen = Math.max(
+    "Values".length,
+    ...keys.map((key) => parameters[key].length
+    ),
+  );
+
+  logger.info("┌".padEnd(keyLen + 3, "─") + "┬" + "".padEnd(valueLen + 2, "─") + "┐");
+  logger.info(`│ ${"Parameters".padEnd(keyLen)} │ ${"Values".padEnd(valueLen)} │`);
+  logger.info("├".padEnd(keyLen + 3, "─") + "┼" + "".padEnd(valueLen + 2, "─") + "┤");
+  keys.sort().forEach((key) => {
+    const value = parameters[key];
+    logger.info(`│ ${key.padEnd(keyLen)} │ ${value.padEnd(valueLen)} │`);
+  });
+  logger.info("└".padEnd(keyLen + 3, "─") + "┴" + "".padEnd(valueLen + 2, "─") + "┘");
+}

--- a/packages/resources/src/Function.ts
+++ b/packages/resources/src/Function.ts
@@ -998,6 +998,9 @@ export class Function extends lambda.Function implements SSTConstruct {
         secrets: (config || [])
           .filter((c) => c instanceof Secret)
           .map((c) => c.name),
+        parameters: (config || [])
+          .filter((c) => c instanceof Parameter)
+          .map((c) => c.name),
       },
     };
   }

--- a/www/docs/constructs/App.tsdoc.md
+++ b/www/docs/constructs/App.tsdoc.md
@@ -46,6 +46,22 @@ The stage the app is being deployed to. If this is not specified as the --stage 
 
 ## Methods
 An instance of `App` has the following methods.
+### addDefaultFunctionConfig
+
+```ts
+addDefaultFunctionConfig(config)
+```
+_Parameters_
+- __config__ <span class='mono'>Array&lt;<span class='mono'><span class="mono">[Secret](Secret#secret)</span> | <span class="mono">[Parameter](Parameter#parameter)</span></span>&gt;</span>
+
+
+Adds additional default config to be applied to all Lambda functions in the app.
+
+
+```js
+app.addDefaultFunctionConfig([STRIPE_KEY])
+```
+
 ### addDefaultFunctionEnv
 
 ```ts

--- a/www/docs/constructs/Function.tsdoc.md
+++ b/www/docs/constructs/Function.tsdoc.md
@@ -50,7 +50,7 @@ new Function(stack, "Function", {
 
 ### config?
 
-_Type_ : <span class='mono'>Array&lt;<span class='mono'><span class="mono">[Parameter](Parameter#parameter)</span> | <span class="mono">[Secret](Secret#secret)</span></span>&gt;</span>
+_Type_ : <span class='mono'>Array&lt;<span class='mono'><span class="mono">[Secret](Secret#secret)</span> | <span class="mono">[Parameter](Parameter#parameter)</span></span>&gt;</span>
 
 Configure environment variables for the function
 
@@ -309,6 +309,24 @@ The AWS generated URL of the Function.
 
 ## Methods
 An instance of `Function` has the following methods.
+### addConfig
+
+```ts
+addConfig(config)
+```
+_Parameters_
+- __config__ <span class='mono'>Array&lt;<span class='mono'><span class="mono">[Secret](Secret#secret)</span> | <span class="mono">[Parameter](Parameter#parameter)</span></span>&gt;</span>
+
+
+Attaches additional configs to function
+
+
+```js
+const STRIPE_KEY = new Config.Secret(stack, "STRIPE_KEY");
+
+fn.addConfig([STRIPE_KEY]);
+```
+
 ### attachPermissions
 
 ```ts

--- a/www/docs/constructs/Stack.tsdoc.md
+++ b/www/docs/constructs/Stack.tsdoc.md
@@ -24,6 +24,22 @@ The current stage of the stack.
 
 ## Methods
 An instance of `Stack` has the following methods.
+### addDefaultFunctionConfig
+
+```ts
+addDefaultFunctionConfig(config)
+```
+_Parameters_
+- __config__ <span class='mono'>Array&lt;<span class='mono'><span class="mono">[Secret](Secret#secret)</span> | <span class="mono">[Parameter](Parameter#parameter)</span></span>&gt;</span>
+
+
+Adds additional default config to be applied to all Lambda functions in the stack.
+
+
+```js
+stack.addDefaultFunctionConfig([STRIPE_KEY]);
+```
+
 ### addDefaultFunctionEnv
 
 ```ts
@@ -101,13 +117,6 @@ stack.addOutputs({
 });
 ```
 
-### createStackMetadataResource
-
-```ts
-createStackMetadataResource(metadata)
-```
-_Parameters_
-- __metadata__ <span class="mono">any</span>
 ### getAllFunctions
 
 ```ts
@@ -140,3 +149,11 @@ stack.setDefaultFunctionProps({
   runtime: "nodejs16.x",
 });
 ```
+
+### setStackMetadata
+
+```ts
+setStackMetadata(metadata)
+```
+_Parameters_
+- __metadata__ <span class="mono">any</span>


### PR DESCRIPTION
- updated `Function` construct to include parameters in the construct metadata
- add methods to get, set, remove parameters and restartAllFunctionsUsingParameter in `function-config`
- created a chalk script for the `parameters` CLI subcommand
- updated the base CLI chalk script to include the `parameters` subcommand
- included auto-generated docs