### PR TITLE
Add useSession import to clarify Auth docs

### DIFF
--- a/www/docs/auth.md
+++ b/www/docs/auth.md
@@ -288,6 +288,8 @@ The `useSession` hook can be called in any part of your API.
 Here's an example of a GraphQL query that gets the current user from the session.
 
 ```js title="services/functions/graphql/types/foo.ts"
+import { useSession } from "@serverless-stack/node/auth";
+
 builder.mutationFields((t) => ({
   createTask: t.field({
     type: TaskType,


### PR DESCRIPTION
This code snippet is the first time you see `useSession` used and there's no mention up to this point where that import comes from. The first time I went through this I had to search the repo for `useSession` to find it. Although it's now mentioned lower in the page, having the import there will ensure copy to clipboard has everything you need for a quick paste  without having to scroll further and/or search the repo.