### PR TITLE
JSON parsing causes local development to fail

### DIFF
--- a/packages/core/src/stacks/metadata.ts
+++ b/packages/core/src/stacks/metadata.ts
@@ -42,8 +42,8 @@ export async function metadata(root: string, config: Config) {
         })
         .promise();
       // Parse the file
-      const json = JSON.parse(ret.Body!.toString());
-      return json;
+      const body = ret.Body!.toString();
+      return body;
     })
   );
   return result.flat();


### PR DESCRIPTION
JSON parsing in line 45 causes local development to fail in NodeJs 16.3

As soon as I get rid of JSON.parse, it works well as expected.