### PR TITLE
Replace "\n" by ";" on custom-resoruces build.

### DIFF
--- a/.changeset/new-pugs-dream.md
+++ b/.changeset/new-pugs-dream.md
@@ -1,0 +1,7 @@
+---
+"@serverless-stack/cli2": patch
+"@serverless-stack/core": patch
+"@serverless-stack/resources": patch
+---
+
+Fix "Could not unzip uploaded file" deployment error

--- a/packages/cli2/src/stacks/build.ts
+++ b/packages/cli2/src/stacks/build.ts
@@ -35,9 +35,9 @@ export async function build() {
     outfile,
     banner: {
       js: [
-        `import { createRequire as topLevelCreateRequire } from 'module'`,
-        `const require = topLevelCreateRequire(import.meta.url)`,
-      ].join("\n"),
+        `import { createRequire as topLevelCreateRequire } from 'module';`,
+        `const require = topLevelCreateRequire(import.meta.url);`,
+      ].join(""),
     },
     // The entry can have any file name (ie. "stacks/anything.ts"). We want the
     // build output to be always named "lib/index.js". This allow us to always

--- a/packages/core/src/runtime/handler/node.ts
+++ b/packages/core/src/runtime/handler/node.ts
@@ -87,10 +87,10 @@ export const NodeHandler: Definition<Bundle> = opts => {
         format: "esm",
         banner: {
           js: [
-            `import { createRequire as topLevelCreateRequire } from 'module'`,
-            `const require = topLevelCreateRequire(import.meta.url)`,
+            `import { createRequire as topLevelCreateRequire } from 'module';`,
+            `const require = topLevelCreateRequire(import.meta.url);`,
             bundle.banner || ""
-          ].join("\n")
+          ].join("")
         }
       }
       : {

--- a/packages/core/src/stacks/build.ts
+++ b/packages/core/src/stacks/build.ts
@@ -36,9 +36,9 @@ export async function build(root: string, config: Config) {
     ],
     banner: {
       js: [
-        `import { createRequire as topLevelCreateRequire } from 'module'`,
-        `const require = topLevelCreateRequire(import.meta.url)`,
-      ].join("\n"),
+        `import { createRequire as topLevelCreateRequire } from 'module';`,
+        `const require = topLevelCreateRequire(import.meta.url);`,
+      ].join(""),
     },
     // The entry can have any file name (ie. "stacks/anything.ts"). We want the
     // build output to be always named "lib/index.js". This allow us to always
@@ -84,8 +84,7 @@ export function formatDiagnostics(list: Diagnostic[]) {
       );
       const message = bottom(diagnostic.messageText);
       return [
-        `${diagnostic.file.fileName} (${line + 1},${
-          character + 1
+        `${diagnostic.file.fileName} (${line + 1},${character + 1
         }): ${message}`,
         `${line - 1}. ${diagnostic.file.text.split("\n")[line - 1]}`,
         chalk.yellow(`${line}. ${diagnostic.file.text.split("\n")[line]}`),

--- a/packages/resources/support/bridge/build.mjs
+++ b/packages/resources/support/bridge/build.mjs
@@ -10,9 +10,9 @@ await esbuild.build({
   entryPoints: ["./support/bridge/bridge.ts"],
   banner: {
     js: [
-      `import { createRequire as topLevelCreateRequire } from 'module'`,
-      `const require = topLevelCreateRequire(import.meta.url)`,
-    ].join("\n"),
+      `import { createRequire as topLevelCreateRequire } from 'module';`,
+      `const require = topLevelCreateRequire(import.meta.url);`,
+    ].join(""),
   },
   outfile: "./dist/support/bridge/bridge.mjs",
 });

--- a/packages/resources/support/custom-resources/build.mjs
+++ b/packages/resources/support/custom-resources/build.mjs
@@ -12,7 +12,7 @@ await esbuild.build({
     js: [
       `import { createRequire as topLevelCreateRequire } from 'module'`,
       `const require = topLevelCreateRequire(import.meta.url)`,
-    ].join("\n"),
+    ].join(";"),
   },
   outfile: "./dist/support/custom-resources/index.mjs",
 });

--- a/packages/resources/support/custom-resources/build.mjs
+++ b/packages/resources/support/custom-resources/build.mjs
@@ -10,9 +10,9 @@ await esbuild.build({
   entryPoints: ["./support/custom-resources/index.ts"],
   banner: {
     js: [
-      `import { createRequire as topLevelCreateRequire } from 'module'`,
-      `const require = topLevelCreateRequire(import.meta.url)`,
-    ].join(";"),
+      `import { createRequire as topLevelCreateRequire } from 'module';`,
+      `const require = topLevelCreateRequire(import.meta.url);`,
+    ].join(""),
   },
   outfile: "./dist/support/custom-resources/index.mjs",
 });


### PR DESCRIPTION
I'm having an issue with a ".zip" corrupted file being uploaded to S3. It comes from a "\n" being placed on the output file:
https://github.com/serverless-stack/sst/blob/6f72f3c11c03abb4163941efd2c0a718741a33d8/packages/resources/support/custom-resources/build.mjs#L12-L15
Related issue: #2069 