### PR TITLE
Function: Add support for AL2 runtime

### DIFF
--- a/packages/resources/src/Function.ts
+++ b/packages/resources/src/Function.ts
@@ -48,6 +48,7 @@ const supportedRuntimes = {
   "java8": lambda.Runtime.JAVA_8,
   "java11": lambda.Runtime.JAVA_11,
   "go1.x": lambda.Runtime.GO_1_X,
+  "provided.al2": lambda.Runtime.PROVIDED_AL2,
 };
 
 export type Runtime = keyof typeof supportedRuntimes;


### PR DESCRIPTION
Lambda layers for using OTEL are currently restricted to the provided.al2 runtime, see here https://aws-otel.github.io/docs/getting-started/lambda/lambda-go.