### PR TITLE
Docs: Remix Site - Add S3 bucket block public access example

### DIFF
--- a/www/docs/constructs/RemixSite.about.md
+++ b/www/docs/constructs/RemixSite.about.md
@@ -525,3 +525,20 @@ api.addRoutes(stack, {
   },
 });
 ```
+
+#### Block public access to the S3 bucket
+
+By default SST creates the S3 bucket with public read access. You can specify more limited bucket permissions if needed. 
+```js
+import * as s3 from "aws-cdk-lib/aws-s3";
+
+new RemixSite(stack, "Site", {
+  path: "my-remix-app/",
+  cdk: {
+    bucket: {
+      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+      publicReadAccess: false,
+    },
+  },
+});
+```


### PR DESCRIPTION
Many organizations have policies limiting public S3 bucket access, this will provide an example in the docs for overriding the default public read access SST grants when creating the S3 bucket for a Remix site. 