### PR TITLE
Build pothos schema if route type is "graphql"

### DIFF
--- a/.changeset/dry-dingos-search.md
+++ b/.changeset/dry-dingos-search.md
@@ -1,0 +1,6 @@
+---
+"@serverless-stack/core": patch
+"@serverless-stack/resources": patch
+---
+
+Api: fix pothos schema not built for "graphql" route type

--- a/packages/core/src/cli/PothosBuilder.ts
+++ b/packages/core/src/cli/PothosBuilder.ts
@@ -51,7 +51,7 @@ export function createPothosBuilder(opts: Opts) {
     routes = evt.properties.metadata
       .filter(c => c.type == "Api")
       .flatMap(c => c.data.routes)
-      .filter(r => r.type === "pothos")
+      .filter(r => ["pothos", "graphql"].includes(r.type))
       .filter(r => r.schema);
     for (const route of routes) build(route);
   });

--- a/packages/resources/src/Api.ts
+++ b/packages/resources/src/Api.ts
@@ -9,7 +9,6 @@ import * as apigIntegrations from "@aws-cdk/aws-apigatewayv2-integrations-alpha"
 import * as elb from "aws-cdk-lib/aws-elasticloadbalancingv2";
 import * as lambda from "aws-cdk-lib/aws-lambda";
 import * as logs from "aws-cdk-lib/aws-logs";
-import spawn from "cross-spawn";
 
 import { App } from "./App.js";
 import { Stack } from "./Stack.js";


### PR DESCRIPTION
Pothos schema wouldn't be built if using the new 1.18 "graphql" route type.