### PR TITLE
Api: Adding `usePathParams`/`usePathParam` helpers

### DIFF
--- a/packages/node/src/api/index.ts
+++ b/packages/node/src/api/index.ts
@@ -104,3 +104,13 @@ export function useQueryParams() {
 export function useQueryParam(name: string) {
   return useQueryParams()[name];
 }
+
+export function usePathParams() {
+  const evt = useEvent("api");
+  const path = evt.pathParameters || {};
+  return path;
+}
+
+export function usePathParam(name: string) {
+  return usePathParams()[name];
+}


### PR DESCRIPTION
There was an existing `usePath` but it returned an array of path segments (split on `/`). If you define your route like this:

```typescript
{
  'POST /user/{id}': 'function/user/update.handler',
}

```

Then `id` will be present in `event.pathParameters`. In this case you could also get the id with:

```
const path = usePath();
const id = path[1];
```

But it's much nicer to use the 'named' path param by getting it from `event.pathParameters`. Especially if you are trying to re-use code where the `id` might not always be in the same position in the path.