### PR TITLE
console: Enable CMD/Ctrl + Enter to submit form

### DIFF
--- a/packages/console/src/App/Stage/Api/index.tsx
+++ b/packages/console/src/App/Stage/Api/index.tsx
@@ -345,7 +345,14 @@ export function Explorer() {
             {form.watch("route") && (
               <Request>
                 <FormProvider {...form}>
-                  <form onSubmit={onSubmit}>
+                  <form
+                    onSubmit={onSubmit}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" && e.metaKey) {
+                        onSubmit();
+                      }
+                    }}
+                  >
                     <RequestTabs>
                       {form.watch("path").length > 0 && (
                         <RequestTabsItem replace to="url">

--- a/packages/console/src/App/Stage/Functions/Detail.tsx
+++ b/packages/console/src/App/Stage/Functions/Detail.tsx
@@ -149,7 +149,14 @@ const Invoke = memo((props: { metadata: FunctionMetadata }) => {
 
   return (
     <InvokeRoot>
-      <form onSubmit={onSubmit}>
+      <form
+        onSubmit={onSubmit}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" && e.metaKey) {
+            onSubmit();
+          }
+        }}
+      >
         <InvokeTextarea
           maxRows={20}
           minRows={5}


### PR DESCRIPTION
This enables CMD + Enter to submit the form on the API or Function pages in the sst console (Ctrl + Enter for Windows).

I've tested this locally and confirmed it passes in the correct query params, headers, and body for API.

Issue: https://github.com/serverless-stack/sst/issues/2276