### PR TITLE
Api: Adding `usePathParams`/`usePathParam` helpers [sst2]

### DIFF
--- a/packages/sst/src/node/api/index.ts
+++ b/packages/sst/src/node/api/index.ts
@@ -105,3 +105,13 @@ export function useQueryParams() {
 export function useQueryParam(name: string) {
   return useQueryParams()[name];
 }
+
+export function usePathParams() {
+  const evt = useEvent("api");
+  const path = evt.pathParameters || {};
+  return path;
+}
+
+export function usePathParam(name: string) {
+  return usePathParams()[name];
+}

--- a/www/docs/clients/api.md
+++ b/www/docs/clients/api.md
@@ -241,3 +241,25 @@ This hook returns all request query parameters.
 import { useQueryParams } from "@serverless-stack/node/api";
 const params = useQueryParams();
 ```
+
+---
+
+### usePathParam
+
+This hook returns a request path parameter.
+
+```ts
+import { usePathParam } from "@serverless-stack/node/api";
+const id = usePathParam("id");
+```
+
+---
+
+### usePathParams
+
+This hook returns all request query parameters.
+
+```ts
+import { usePathParams } from "@serverless-stack/node/api";
+const params = usePathParams();
+```


### PR DESCRIPTION
Note: Same as #2279 but this time for the sst2 branch

There was an existing `usePath` but it returned an array of path segments (split on `/`). If you define your route like this:

```typescript
{
  'POST /user/{id}': 'function/user/update.handler',
}

```

Then `id` will be present in `event.pathParameters`. In this case you could also get the id with:

```
const path = usePath();
const id = path[1];
```

But it's much nicer to use the 'named' path param by getting it from `event.pathParameters`. Especially if you are trying to re-use code where the `id` might not always be in the same position in the path.