### PR TITLE
fix: enable /ping endpoint for console.sst.dev 

### DIFF
--- a/packages/sst/src/cli/local/server.ts
+++ b/packages/sst/src/cli/local/server.ts
@@ -41,7 +41,6 @@ export async function useLocalServer(opts: Opts) {
 
   const rest = express();
 
-  /*
   rest.all(`/ping`, (req, res) => {
     res.header("Access-Control-Allow-Origin", "*");
     res.header("Access-Control-Allow-Methods", "GET, PUT, PATCH, POST, DELETE");
@@ -51,8 +50,7 @@ export async function useLocalServer(opts: Opts) {
     );
     res.sendStatus(200);
   });
-  */
-
+  
   rest.all<{
     href: string;
   }>(


### PR DESCRIPTION
Fixes issue w/ console.sst.dev failing to call the `/ping` endpoint, thus rendering the console site useless.