### PR TITLE
Update the bind command to inherit the full env of the parent process

### DIFF
--- a/.changeset/young-ducks-impress.md
+++ b/.changeset/young-ducks-impress.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+Update bind to inherit the full env of the parent process

--- a/packages/sst/src/cli/commands/bind.ts
+++ b/packages/sst/src/cli/commands/bind.ts
@@ -27,12 +27,12 @@ export const bind = (program: Program) =>
       const credentials = await useAWSCredentials();
       const result = spawnSync(args.command, {
         env: {
+          ...process.env,
           ...env,
           AWS_ACCESS_KEY_ID: credentials.accessKeyId,
           AWS_SECRET_ACCESS_KEY: credentials.secretAccessKey,
           AWS_SESSION_TOKEN: credentials.sessionToken,
           AWS_REGION: project.config.region,
-          PATH: process.env.PATH,
         },
         stdio: "inherit",
         shell: process.env.SHELL || true,


### PR DESCRIPTION
Usecase: There are a number of scenarios e.g. CI with Github Actions, Circle CI and others use environment variables to pass values derived during each step it the workflow. Or they define a $CI env var to define that your code/tests are running in the CI environment.

When using `sst bind 'vitest run'` or `sst bind 'playwright test'` the process.env of the parent process is not passed in full to the newly spawned test runner. Instead only the config loaded from AWS is spread and AWS_* credentials.

This change first spreads the full ENV of the parent process e.g. the CI runner to the process spawned by the bind command.