### PR TITLE
Removing unnecessary "v" prefix on the version for the release notes

### DIFF
--- a/.changeset/aggregate.mjs
+++ b/.changeset/aggregate.mjs
@@ -54,8 +54,8 @@ const notes = [
   `---`,
   `Update using:`,
   "``` sh",
-  "$ npx sst update v" + version,
-  "$ yarn sst update v" + version,
+  "$ npx sst update " + version,
+  "$ yarn sst update " + version,
   "```",
 ];
 console.log(notes.join("\n"));


### PR DESCRIPTION
It causes errors when running `npx sst update`:

```sh
% npx sst update v2.0.0-rc.32
Error: Cannot read properties of undefined (reading 'constructs')

Trace: TypeError: Cannot read properties of undefined (reading 'constructs')
    at file:///Users/josh/git/USERNAME/PROJECT/node_modules/sst/cli/commands/update.js:32:54
    at file:///Users/josh/git/USERNAME/PROJECT/node_modules/sst/cli/commands/update.js:36:19
    at async Promise.all (index 2)
    at async Object.handler (file:///Users/josh/git/USERNAME/PROJECT/node_modules/sst/cli/commands/update.js:50:5)
    at process.<anonymous> (file:///Users/josh/git/USERNAME/PROJECT/node_modules/sst/cli/sst.js:40:17)
    at process.emit (node:events:525:35)
    at process.emit (node:domain:489:12)
    at process._fatalException (node:internal/process/execution:149:25)
    at processPromiseRejections (node:internal/process/promises:279:13)
    at processTicksAndRejections (node:internal/process/task_queues:97:32)
```

With the "v" removed it works:

```sh
% npx sst update 2.0.0-rc.32
✅ services/package.json
     sst@2.0.0-rc.32
✅ package.json
     constructs@10.1.156
     sst@2.0.0-rc.32
✅ frontend/package.json
     sst@2.0.0-rc.32
```