### PR TITLE
feat: add architecture props to site constructs

### DIFF
--- a/packages/sst/src/constructs/AstroSite.ts
+++ b/packages/sst/src/constructs/AstroSite.ts
@@ -56,6 +56,7 @@ export class AstroSite extends SsrSite {
       handler,
       logRetention: "three_days",
       runtime: "nodejs16.x",
+      architecture: defaults?.function?.architecture,
       memorySize: defaults?.function?.memorySize || "512 MB",
       timeout: defaults?.function?.timeout || "10 seconds",
       nodejs: {

--- a/packages/sst/src/constructs/Function.ts
+++ b/packages/sst/src/constructs/Function.ts
@@ -84,10 +84,6 @@ export interface FunctionProps
     | "logRetention"
   > {
   /**
-   * Used to configure bundled code.
-   */
-  code?: lambda.Code;
-  /**
    * Used to configure additional files to copy into the function bundle
    *
    * @example
@@ -702,7 +698,7 @@ export class Function extends lambda.Function implements SSTConstruct {
       super(scope, id, {
         ...props,
         architecture,
-        code: props.code || lambda.Code.fromAsset(
+        code: lambda.Code.fromAsset(
           path.resolve(__dirname, "../support/bridge")
         ),
         handler: "bridge.handler",

--- a/packages/sst/src/constructs/Function.ts
+++ b/packages/sst/src/constructs/Function.ts
@@ -84,6 +84,10 @@ export interface FunctionProps
     | "logRetention"
   > {
   /**
+   * Used to configure bundled code.
+   */
+  code?: lambda.Code;
+  /**
    * Used to configure additional files to copy into the function bundle
    *
    * @example
@@ -698,7 +702,7 @@ export class Function extends lambda.Function implements SSTConstruct {
       super(scope, id, {
         ...props,
         architecture,
-        code: lambda.Code.fromAsset(
+        code: props.code || lambda.Code.fromAsset(
           path.resolve(__dirname, "../support/bridge")
         ),
         handler: "bridge.handler",

--- a/packages/sst/src/constructs/NextjsSite.ts
+++ b/packages/sst/src/constructs/NextjsSite.ts
@@ -17,6 +17,7 @@ import * as cloudfront from "aws-cdk-lib/aws-cloudfront";
 import * as origins from "aws-cdk-lib/aws-cloudfront-origins";
 
 import { SsrSite, SsrSiteProps } from "./SsrSite.js";
+import { Function } from "./Function.js";
 import { EdgeFunction } from "./EdgeFunction.js";
 
 const __dirname = url.fileURLToPath(new URL(".", import.meta.url));
@@ -88,17 +89,18 @@ export class NextjsSite extends SsrSite {
       handler = "index.handler";
     }
 
-    return new lambda.Function(this, `ServerFunction`, {
+    return new Function(this, `ServerFunction`, {
       description: "Server handler for Next.js",
       handler,
       currentVersionOptions: {
         removalPolicy: RemovalPolicy.DESTROY,
       },
-      logRetention: logs.RetentionDays.THREE_DAYS,
+      logRetention: 'three_days',
       code: lambda.Code.fromAsset(bundlePath),
-      runtime: lambda.Runtime.NODEJS_18_X,
+      architecture: defaults?.function?.architecture,
+      runtime: 'nodejs18.x',
       memorySize: defaults?.function?.memorySize || 512,
-      timeout: Duration.seconds(defaults?.function?.timeout || 10),
+      timeout: defaults?.function?.timeout || '10 seconds',
       environment,
     });
   }

--- a/packages/sst/src/constructs/NextjsSite.ts
+++ b/packages/sst/src/constructs/NextjsSite.ts
@@ -98,10 +98,15 @@ export class NextjsSite extends SsrSite {
       logRetention: 'three_days',
       code: lambda.Code.fromAsset(bundlePath),
       architecture: defaults?.function?.architecture,
-      runtime: 'nodejs18.x',
+      runtime: defaults?.function?.runtime || 'nodejs18.x',
       memorySize: defaults?.function?.memorySize || 512,
       timeout: defaults?.function?.timeout || '10 seconds',
       environment,
+      url: {
+        cors: {
+          
+        }
+      }
     });
   }
 

--- a/packages/sst/src/constructs/NextjsSite.ts
+++ b/packages/sst/src/constructs/NextjsSite.ts
@@ -99,7 +99,7 @@ export class NextjsSite extends SsrSite {
       logRetention: logs.RetentionDays.THREE_DAYS,
       code: lambda.Code.fromAsset(bundlePath),
       architecture: defaults?.function?.architecture === 'arm_64' ? lambda.Architecture.ARM_64 : lambda.Architecture.X86_64,
-      runtime: lambda.Runtime.NODEJS_18_X,
+      runtime: defaults?.function?.runtime || lambda.Runtime.NODEJS_18_X,
       memorySize: defaults?.function?.memorySize || 512,
       timeout: Duration.seconds(defaults?.function?.timeout || 10),
       environment,

--- a/packages/sst/src/constructs/NextjsSite.ts
+++ b/packages/sst/src/constructs/NextjsSite.ts
@@ -1,7 +1,6 @@
 import fs from "fs";
 import url from "url";
 import path from "path";
-import esbuild from "esbuild";
 import spawn from "cross-spawn";
 import { Construct } from "constructs";
 import { buildErrorResponsesForRedirectToIndex } from "./BaseSite.js";
@@ -9,13 +8,11 @@ import {
   Fn,
   Duration,
   RemovalPolicy,
-  SymlinkFollowMode,
 } from "aws-cdk-lib";
 import * as logs from "aws-cdk-lib/aws-logs";
 import * as lambda from "aws-cdk-lib/aws-lambda";
 import * as cloudfront from "aws-cdk-lib/aws-cloudfront";
 import * as origins from "aws-cdk-lib/aws-cloudfront-origins";
-import { Permissions } from "./util/permission.js";
 
 import { SsrSite, SsrSiteProps } from "./SsrSite.js";
 import { EdgeFunction } from "./EdgeFunction.js";

--- a/packages/sst/src/constructs/RemixSite.ts
+++ b/packages/sst/src/constructs/RemixSite.ts
@@ -11,7 +11,6 @@ import * as lambda from "aws-cdk-lib/aws-lambda";
 
 import { Logger } from "../logger.js";
 import { SsrSite } from "./SsrSite.js";
-import { Function } from "./Function.js";
 import { EdgeFunction } from "./EdgeFunction.js";
 
 const __dirname = url.fileURLToPath(new URL(".", import.meta.url));
@@ -167,18 +166,18 @@ export class RemixSite extends SsrSite {
       ? this.createServerLambdaBundleWithStub()
       : this.createServerLambdaBundle("regional-server.js");
 
-    return new Function(this, `ServerFunction`, {
+    return new lambda.Function(this, `ServerFunction`, {
       description: "Server handler for Remix",
       handler: "server.handler",
       currentVersionOptions: {
         removalPolicy: RemovalPolicy.DESTROY,
       },
-      logRetention: 'three_days',
+      logRetention: logs.RetentionDays.THREE_DAYS,
       code: lambda.Code.fromAsset(bundlePath),
-      architecture: defaults?.function?.architecture,
-      runtime: defaults?.function?.runtime || 'nodejs16.x',
+      architecture: defaults?.function?.architecture === 'arm_64' ? lambda.Architecture.ARM_64 : lambda.Architecture.X86_64,
+      runtime: lambda.Runtime.NODEJS_16_X,
       memorySize: defaults?.function?.memorySize || 512,
-      timeout: defaults?.function?.timeout || '10 seconds',
+      timeout: Duration.seconds(defaults?.function?.timeout || 10),
       environment,
     });
   }

--- a/packages/sst/src/constructs/RemixSite.ts
+++ b/packages/sst/src/constructs/RemixSite.ts
@@ -175,7 +175,7 @@ export class RemixSite extends SsrSite {
       logRetention: logs.RetentionDays.THREE_DAYS,
       code: lambda.Code.fromAsset(bundlePath),
       architecture: defaults?.function?.architecture === 'arm_64' ? lambda.Architecture.ARM_64 : lambda.Architecture.X86_64,
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: defaults?.function?.runtime || lambda.Runtime.NODEJS_16_X,
       memorySize: defaults?.function?.memorySize || 512,
       timeout: Duration.seconds(defaults?.function?.timeout || 10),
       environment,

--- a/packages/sst/src/constructs/RemixSite.ts
+++ b/packages/sst/src/constructs/RemixSite.ts
@@ -11,6 +11,7 @@ import * as lambda from "aws-cdk-lib/aws-lambda";
 
 import { Logger } from "../logger.js";
 import { SsrSite } from "./SsrSite.js";
+import { Function } from "./Function.js";
 import { EdgeFunction } from "./EdgeFunction.js";
 
 const __dirname = url.fileURLToPath(new URL(".", import.meta.url));
@@ -166,17 +167,18 @@ export class RemixSite extends SsrSite {
       ? this.createServerLambdaBundleWithStub()
       : this.createServerLambdaBundle("regional-server.js");
 
-    return new lambda.Function(this, `ServerFunction`, {
+    return new Function(this, `ServerFunction`, {
       description: "Server handler for Remix",
       handler: "server.handler",
       currentVersionOptions: {
         removalPolicy: RemovalPolicy.DESTROY,
       },
-      logRetention: logs.RetentionDays.THREE_DAYS,
+      logRetention: 'three_days',
       code: lambda.Code.fromAsset(bundlePath),
-      runtime: lambda.Runtime.NODEJS_16_X,
+      architecture: defaults?.function?.architecture,
+      runtime: 'nodejs16.x',
       memorySize: defaults?.function?.memorySize || 512,
-      timeout: Duration.seconds(defaults?.function?.timeout || 10),
+      timeout: defaults?.function?.timeout || '10 seconds',
       environment,
     });
   }

--- a/packages/sst/src/constructs/RemixSite.ts
+++ b/packages/sst/src/constructs/RemixSite.ts
@@ -176,7 +176,7 @@ export class RemixSite extends SsrSite {
       logRetention: 'three_days',
       code: lambda.Code.fromAsset(bundlePath),
       architecture: defaults?.function?.architecture,
-      runtime: 'nodejs16.x',
+      runtime: defaults?.function?.runtime || 'nodejs16.x',
       memorySize: defaults?.function?.memorySize || 512,
       timeout: defaults?.function?.timeout || '10 seconds',
       environment,

--- a/packages/sst/src/constructs/SolidStartSite.ts
+++ b/packages/sst/src/constructs/SolidStartSite.ts
@@ -45,6 +45,7 @@ export class SolidStartSite extends SsrSite {
       description: "Server handler",
       handler,
       logRetention: "three_days",
+      architecture: defaults?.function?.architecture,
       runtime: "nodejs16.x",
       memorySize: defaults?.function?.memorySize || "512 MB",
       timeout: defaults?.function?.timeout || "10 seconds",

--- a/packages/sst/src/constructs/SsrSite.ts
+++ b/packages/sst/src/constructs/SsrSite.ts
@@ -129,6 +129,9 @@ export interface SsrSiteProps {
 
   defaults?: {
     function?: {
+      architecture?: Lowercase<
+        keyof Pick<typeof lambda.Architecture, "ARM_64" | "X86_64">
+      >; 
       timeout?: number;
       memorySize?: number;
       permissions?: Permissions;

--- a/packages/sst/src/constructs/SsrSite.ts
+++ b/packages/sst/src/constructs/SsrSite.ts
@@ -30,7 +30,6 @@ import { App } from "./App.js";
 import { Stack } from "./Stack.js";
 import { Logger } from "../logger.js";
 import { SSTConstruct, isCDKConstruct } from "./Construct.js";
-import { Runtime } from './Function.js'
 import { EdgeFunction } from "./EdgeFunction.js";
 import {
   BaseSiteDomainProps,

--- a/packages/sst/src/constructs/SsrSite.ts
+++ b/packages/sst/src/constructs/SsrSite.ts
@@ -135,7 +135,7 @@ export interface SsrSiteProps {
       >; 
       memorySize?: number;
       permissions?: Permissions;
-      runtime?: Runtime;
+      runtime?: lambda.Runtime;
       timeout?: number;
     };
   };

--- a/packages/sst/src/constructs/SsrSite.ts
+++ b/packages/sst/src/constructs/SsrSite.ts
@@ -30,6 +30,7 @@ import { App } from "./App.js";
 import { Stack } from "./Stack.js";
 import { Logger } from "../logger.js";
 import { SSTConstruct, isCDKConstruct } from "./Construct.js";
+import { Runtime } from './Function.js'
 import { EdgeFunction } from "./EdgeFunction.js";
 import {
   BaseSiteDomainProps,
@@ -132,9 +133,10 @@ export interface SsrSiteProps {
       architecture?: Lowercase<
         keyof Pick<typeof lambda.Architecture, "ARM_64" | "X86_64">
       >; 
-      timeout?: number;
       memorySize?: number;
       permissions?: Permissions;
+      runtime?: Runtime;
+      timeout?: number;
     };
   };
 


### PR DESCRIPTION
This PR adds the `architecture` prop to the `Site` Constructs.

Use case: I want to use `arm_64` as my lambda function architecture to take advantage of the Graviton2 CPU for lower costs.
See: https://aws.amazon.com/blogs/aws/aws-lambda-functions-powered-by-aws-graviton2-processor-run-your-functions-on-arm-and-get-up-to-34-better-price-performance/

NOTE:
The `NextjsSite` and `RemixSite` do not use the sst `Function`. I refactored it a little so it uses the same pattern as the others.
I haven't tested this so there may be missing configs elsewhere.

Edit: I reverted the change to use the `sst.Function`.