### PR TITLE
fix: typo in jsdoc examples

### DIFF
--- a/packages/sst/src/constructs/Function.ts
+++ b/packages/sst/src/constructs/Function.ts
@@ -412,7 +412,7 @@ export interface NodeJSProps {
    * @example
    * ```js
    * new Function(stack, "Function", {
-   *   bundle: {
+   *   nodejs: {
    *     loader: {
    *      ".png": "file"
    *     }
@@ -428,7 +428,7 @@ export interface NodeJSProps {
    * @example
    * ```js
    * new Function(stack, "Function", {
-   *   bundle: {
+   *   nodejs: {
    *     nodeModules: ["pg"]
    *   }
    * })
@@ -442,7 +442,7 @@ export interface NodeJSProps {
    * @example
    * ```js
    * new Function(stack, "Function", {
-   *   bundle: {
+   *   nodejs: {
    *     banner: "console.log('Function starting')"
    *   }
    * })
@@ -463,7 +463,7 @@ export interface NodeJSProps {
    * @example
    * ```js
    * new Function(stack, "Function", {
-   *   bundle: {
+   *   nodejs: {
    *     minify: false
    *   }
    * })
@@ -478,7 +478,7 @@ export interface NodeJSProps {
    * @example
    * ```js
    * new Function(stack, "Function", {
-   *   bundle: {
+   *   nodejs: {
    *     format: "esm"
    *   }
    * })
@@ -493,8 +493,8 @@ export interface NodeJSProps {
    * @example
    * ```js
    * new Function(stack, "Function", {
-   *   bundle: {
-   *   sourcemap: true
+   *   nodejs: {
+   *     sourcemap: true
    *   }
    * })
    * ```

--- a/packages/sst/src/constructs/Function.ts
+++ b/packages/sst/src/constructs/Function.ts
@@ -514,7 +514,7 @@ export interface JavaProps {
    * @example
    * ```js
    * new Function(stack, "Function", {
-   *   bundle: {
+   *   java: {
    *     buildTask: "bundle"
    *   }
    * })
@@ -529,7 +529,7 @@ export interface JavaProps {
    * @example
    * ```js
    * new Function(stack, "Function", {
-   *   bundle: {
+   *   java: {
    *     buildOutputDir: "output"
    *   }
    * })
@@ -544,7 +544,7 @@ export interface JavaProps {
    * @example
    * ```js
    * new Function(stack, "Function", {
-   *   bundle: {
+   *   java: {
    *     experimentalUseProvidedRuntime: "provided.al2"
    *   }
    * })
@@ -589,9 +589,7 @@ export interface FunctionBundlePythonProps extends FunctionBundleBase {
  * @example
  * ```js
  * new Function(stack, "Function", {
- *   bundle: {
- *     copyFiles: [{ from: "src/index.js" }]
- *   }
+ *   copyFiles: [{ from: "src/index.js" }]
  * })
  *```
  */


### PR DESCRIPTION
`bundle` has been renamed to `nodejs`. Not sure if there are more things renamed.