### PR TITLE
feat: vpc config for ssr sites

### DIFF
--- a/packages/sst/src/constructs/AstroSite.ts
+++ b/packages/sst/src/constructs/AstroSite.ts
@@ -44,14 +44,23 @@ export class AstroSite extends SsrSite {
   }
 
   protected createFunctionForRegional(): lambda.Function {
-    const { defaults, environment, bind } = this.props;
+    const {
+      defaults,
+      environment,
+      bind,
+      vpc,
+      vpcSubnets,
+      securityGroups,
+      allowAllOutbound,
+      allowPublicSubnet,
+    } = this.props;
 
     // Bundle code
     const handler = this.isPlaceholder
       ? path.resolve(
-          __dirname,
-          "../support/ssr-site-function-stub/index.handler"
-        )
+        __dirname,
+        "../support/ssr-site-function-stub/index.handler"
+      )
       : path.join(this.props.path, "dist", "server", "entry.handler");
 
     // Create function
@@ -59,6 +68,11 @@ export class AstroSite extends SsrSite {
       description: "Server handler",
       handler,
       bind,
+      vpc,
+      vpcSubnets,
+      securityGroups,
+      allowAllOutbound,
+      allowPublicSubnet,
       logRetention: "three_days",
       runtime: "nodejs16.x",
       memorySize: defaults?.function?.memorySize || "512 MB",

--- a/packages/sst/src/constructs/RemixSite.ts
+++ b/packages/sst/src/constructs/RemixSite.ts
@@ -37,7 +37,6 @@ type RemixConfig = {
  * ```
  */
 export class RemixSite extends SsrSite {
-
   protected initBuildConfig() {
     const { path: sitePath } = this.props;
 
@@ -108,7 +107,7 @@ export class RemixSite extends SsrSite {
     // Write the server lambda
     const templatePath = path.resolve(
       __dirname,
-      `../support/remix-site-function/${wrapperFile}`,
+      `../support/remix-site-function/${wrapperFile}`
     );
     fs.copyFileSync(templatePath, serverPath);
 
@@ -160,7 +159,15 @@ export class RemixSite extends SsrSite {
   }
 
   protected createFunctionForRegional(): lambda.Function {
-    const { defaults, environment } = this.props;
+    const {
+      defaults,
+      environment,
+      vpc,
+      vpcSubnets,
+      securityGroups,
+      allowAllOutbound,
+      allowPublicSubnet,
+    } = this.props;
 
     const bundlePath = this.isPlaceholder
       ? this.createServerLambdaBundleWithStub()
@@ -178,6 +185,11 @@ export class RemixSite extends SsrSite {
       memorySize: defaults?.function?.memorySize || 512,
       timeout: Duration.seconds(defaults?.function?.timeout || 10),
       environment,
+      vpc,
+      vpcSubnets,
+      securityGroups,
+      allowAllOutbound,
+      allowPublicSubnet,
     });
   }
 


### PR DESCRIPTION
Adds VPC related configuration for regional lambda functions configured in `SsrSite`'s. I needed this for `AstroSite`, but added it to all of the other constructs as I figured, why not?

_Note: not sure why my prettier added lots of formatting noise, but lmk if you want me to revert all of that._