### PR TITLE
Update resource-binding.md "Cost" documentation

### DIFF
--- a/www/docs/resource-binding.md
+++ b/www/docs/resource-binding.md
@@ -319,7 +319,7 @@ When binding resources that contain sensitive values, placeholders are stored in
 
 ## Cost
 
-Resource Binding values are stored in AWS SSM with the _Standard Parameter type_ and _Standard Throughput_. This makes it [free to use](https://aws.amazon.com/systems-manager/pricing/) in your SST apps.
+Resource Binding values are stored in AWS SSM with the _Standard Parameter type_ and _Standard Throughput_. This makes AWS SSM [free to use](https://aws.amazon.com/systems-manager/pricing/) in your SST apps, however when storing a `Config.Secret` the value is encrypted by AWS KMS. Secrets like this must be retrieved at runtime in you Lambda functions each time the Lambda starts up, AWS KMS has a [free tier](https://aws.amazon.com/kms/pricing/#Free_tier) limit of 20,000 API interactions per month. It costs $0.03 for every 10,000 subsequent AWS KMS API calls, this is important to keep in mind if you need to fetch secrets like database credentials for every request as the costs may add up quick.
 
 ## FAQ
 

--- a/www/docs/resource-binding.md
+++ b/www/docs/resource-binding.md
@@ -319,7 +319,7 @@ When binding resources that contain sensitive values, placeholders are stored in
 
 ## Cost
 
-Resource Binding values are stored in AWS SSM with the _Standard Parameter type_ and _Standard Throughput_. This makes AWS SSM [free to use](https://aws.amazon.com/systems-manager/pricing/) in your SST apps, however when storing a `Config.Secret` the value is encrypted by AWS KMS. Secrets like this must be retrieved at runtime in you Lambda functions each time the Lambda starts up, AWS KMS has a [free tier](https://aws.amazon.com/kms/pricing/#Free_tier) limit of 20,000 API interactions per month. It costs $0.03 for every 10,000 subsequent AWS KMS API calls, this is important to keep in mind if you need to fetch secrets like database credentials for every request as the costs may add up quick.
+Resource Binding values are stored in AWS SSM with the _Standard Parameter type_ and _Standard Throughput_. This makes AWS SSM [free to use](https://aws.amazon.com/systems-manager/pricing/) in your SST apps. However when storing a `Config.Secret` the value is encrypted by AWS KMS. These are retrieved at runtime in your Lambda functions when it starts up. AWS KMS has a [free tier](https://aws.amazon.com/kms/pricing/#Free_tier) of 20,000 API calls per month. And it costs $0.03 for every 10,000 subsequent API calls. This is worth keeping in mind as these secrets are fetched per Lambda function cold start.
 
 ## FAQ
 


### PR DESCRIPTION
I believe an amendment to the "Cost" section of the resource-binding would be helpful. While AWS SSM is free to use, decrypting the secrets in AWS KMS is not free forever, the free tier has 20,000 API interactions per month and costs $0.03 per 10,000 subsequent API calls. I think this might be hit a lot sooner than many might think, I have been working on a Remix app and hit 85% of this limit with 3 secrets when developing this (lots of reloads with file saves etc). The Remix construct also does not have the api for `Config.bind` in order to cache subsequent requests with a warm lambda. This limit can probably be reduced but I believe other will incur costs in production that might otherwise not be anticipated.