### PR TITLE
bug: sst plugin pothos throwing error when no commands array

### DIFF
--- a/.changeset/metal-windows-film.md
+++ b/.changeset/metal-windows-film.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+bug: sst plugin pothos throwing error when no commands array

--- a/packages/sst/src/cli/commands/plugins/pothos.ts
+++ b/packages/sst/src/cli/commands/plugins/pothos.ts
@@ -23,7 +23,9 @@ export const usePothosBuilder = Context.memo(() => {
       });
       await fs.writeFile(route.output, schema);
       // bus.publish("pothos.extracted", { file: route.output });
-      await Promise.all(route.commands.map((cmd: string) => execAsync(cmd)));
+      if (Array.isArray(route.commands) && route.commands.length > 0) {
+        await Promise.all(route.commands?.map((cmd: string) => execAsync(cmd)));
+      }
       Colors.line(Colors.success(`✔`), " Pothos: Extracted pothos schema");
     } catch (ex: any) {
       Colors.line(Colors.danger(`✖`), " Pothos: Failed to extract schema:");

--- a/packages/sst/src/cli/commands/plugins/pothos.ts
+++ b/packages/sst/src/cli/commands/plugins/pothos.ts
@@ -24,7 +24,7 @@ export const usePothosBuilder = Context.memo(() => {
       await fs.writeFile(route.output, schema);
       // bus.publish("pothos.extracted", { file: route.output });
       if (Array.isArray(route.commands) && route.commands.length > 0) {
-        await Promise.all(route.commands?.map((cmd: string) => execAsync(cmd)));
+        await Promise.all(route.commands.map((cmd: string) => execAsync(cmd)));
       }
       Colors.line(Colors.success(`✔`), " Pothos: Extracted pothos schema");
     } catch (ex: any) {


### PR DESCRIPTION
`sst/construct`

When using a `Api` construct with a type of `"graphql"` and you don't provide an `commands` array to the `pothos` object an error is thrown.

```
✖  Pothos: Failed to extract schema:
   Cannot read properties of undefined (reading 'map')
```

example `MyStack.ts`
```typescript
import { StackContext, Api } from "sst/constructs";

export function API({ stack }: StackContext) {
  const api = new Api(stack, "api", {
    routes: {
      "GET /": "packages/functions/src/lambda.handler",
      "POST /graphql": {
        type: "graphql",
        function: "packages/functions/src/graphql.handler",
        pothos: {
          schema: "packages/functions/src/schema.ts",
          output: "graphql/schema.graphql",
          // commands: []
        },
      },
    },
  });
  stack.addOutputs({
    ApiEndpoint: api.url,
  });
}
```

You can provide an empty array to `commands` to avoid this error. But that's not ideal.

This PR should fix the issue and avoid the error when no `commands` array is provided.

I did start to refactor the usage of the `any` in `build(route: any)` to use the `Extract` type from `let routes`. But then `route.schema` and `route.output` could be undefined and I'm not sure if they really should be defined as required in the `pothos` route object when a user defines their API route.

```typescript
type Route = Extract<
  ApiMetadata["data"]["routes"][number],
  { type: "graphql" | "pothos" }
>;
...
let routes: Route[] = [];
async function build(route: Route) {...}
```


