### PR TITLE
Fix: Auth routes secured with default authorizer

### DIFF
--- a/.changeset/large-bottles-live.md
+++ b/.changeset/large-bottles-live.md
@@ -1,0 +1,5 @@
+---
+"sst": major
+---
+
+Fix: Auth routes unauthorized with default authorizer

--- a/packages/sst/src/constructs/Auth.ts
+++ b/packages/sst/src/constructs/Auth.ts
@@ -197,6 +197,7 @@ export class Auth extends Construct implements SSTConstruct {
         [path]: {
           type: "function",
           function: this.authenticator,
+          authorizer: "none",
         },
       });
 


### PR DESCRIPTION
If an API has a default authorizer set and the API has Auth attached, the auth routes were secured and therefor non usable.