### PR TITLE
Fix: Replaced npm_config_yes=true with --yes

### DIFF
--- a/packages/sst/src/constructs/NextjsSite.ts
+++ b/packages/sst/src/constructs/NextjsSite.ts
@@ -50,7 +50,7 @@ export class NextjsSite extends SsrSite {
 
   constructor(scope: Construct, id: string, props?: NextjsSiteProps) {
     super(scope, id, {
-      buildCommand: "npm_config_yes=true npx open-next@latest build",
+      buildCommand: "npx --yes open-next@latest build",
       ...props,
     });
   }


### PR DESCRIPTION
npm_config_yes=true causes following error on windows:
 `npm_config_yes' is not recognized as an internal or external command, operable program or batch file.`

`--yes` achieves the same thing and works cross platforms.