### PR TITLE
fix: handle alternate domain names in SsrSite

### DIFF
--- a/packages/sst/src/constructs/SsrSite.ts
+++ b/packages/sst/src/constructs/SsrSite.ts
@@ -779,6 +779,13 @@ export class SsrSite extends Construct implements SSTConstruct {
       domainNames.push(customDomain);
     } else {
       domainNames.push(customDomain.domainName);
+      if (customDomain.alternateNames) {
+        if (!customDomain.cdk?.certificate)
+          throw new Error(
+            "Certificates for alternate domains cannot be automatically created. Please specify certificate to use"
+          );
+        domainNames.push(...customDomain.alternateNames);
+      }
     }
     return domainNames;
   }


### PR DESCRIPTION
When using the SsrSite construct, the customDomain.alternateNames has no effect on the cloudfront distribution created.
This PR fixes this so that it is in line with what the StaticSite construct does (the code was copy pasted from the staticSite construct)