### PR TITLE
fix(#2417): changing construct name to be dynamic depending on userpool

### DIFF
--- a/packages/sst/src/constructs/ApiGatewayV1Api.ts
+++ b/packages/sst/src/constructs/ApiGatewayV1Api.ts
@@ -1234,7 +1234,7 @@ export class ApiGatewayV1Api<
           const userPools = value.userPoolIds.map((userPoolId) =>
             cognito.UserPool.fromUserPoolId(
               this,
-              `${key}-ImportedUserPool`,
+              `${key}-${userPoolId}-ImportedUserPool`,
               userPoolId
             )
           );


### PR DESCRIPTION
fix for #2417 on sst2 branch as discussed in https://github.com/serverless-stack/sst/pull/2418#issuecomment-1419258647