### PR TITLE
fix: handle alternate domain names for SsrSite construct

### DIFF
--- a/.changeset/grumpy-bobcats-boil.md
+++ b/.changeset/grumpy-bobcats-boil.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+Handle alternate domain names for SsrSite construct

--- a/packages/sst/src/constructs/SsrSite.ts
+++ b/packages/sst/src/constructs/SsrSite.ts
@@ -779,6 +779,13 @@ export class SsrSite extends Construct implements SSTConstruct {
       domainNames.push(customDomain);
     } else {
       domainNames.push(customDomain.domainName);
+      if (customDomain.alternateNames) {
+        if (!customDomain.cdk?.certificate)
+          throw new Error(
+            "Certificates for alternate domains cannot be automatically created. Please specify certificate to use"
+          );
+        domainNames.push(...customDomain.alternateNames);
+      }
     }
     return domainNames;
   }


### PR DESCRIPTION
Currently the alternateNames prop has no effect when set for SsrSite construct (while it is present on many examples)
This PR is pretty basic and is just a copy paste of the code in StaticSite

While working on this I have also found that for both StaticSite and SsrSite the alternate names are only used in the cloudfront distribution settings and the additional route53 records are not created, I can either update this PR to include the code to generate the required route53 records or open a separate PR as this is kind of a different issue that affects both Static and SSR sites.