### PR TITLE
Fixed hardcoded python `services` directory

### DIFF
--- a/.changeset/curly-tigers-tell.md
+++ b/.changeset/curly-tigers-tell.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+Fixed hardcoded python `services` directory

--- a/packages/sst/src/runtime/handlers/python.ts
+++ b/packages/sst/src/runtime/handlers/python.ts
@@ -35,11 +35,11 @@ export const usePythonHandler = Context.memo(async () => {
     },
     canHandle: (input) => input.startsWith("python"),
     startWorker: async (input) => {
-      const src = "services";
+      const src = await findAbove(input.handler, "requirements.txt");
       const parsed = path.parse(path.relative(src, input.handler));
       const target = [...parsed.dir.split(path.sep), parsed.name].join(".");
       const proc = spawn(
-        os.platform() === "win32" ? "python.exe" : "python3.6".split(".")[0],
+        os.platform() === "win32" ? "python.exe" : "python3",
         [
           "-u",
           url.fileURLToPath(
@@ -58,7 +58,7 @@ export const usePythonHandler = Context.memo(async () => {
             AWS_LAMBDA_RUNTIME_API: `localhost:${server.port}/${input.workerID}`,
           },
           shell: true,
-          cwd: path.join(process.cwd(), src),
+          cwd: src,
         }
       );
       proc.on("exit", () => workers.exited(input.workerID));


### PR DESCRIPTION
I was getting this error:
```
|  Invoked src/ ... file.lambda_handler
Error: spawn /bin/sh ENOENT

Trace: Error: spawn /bin/sh ENOENT
    at __node_internal_captureLargerStackTrace (node:internal/errors:478:5)
    at __node_internal_errnoException (node:internal/errors:608:12)
    at Process.ChildProcess._handle.onexit (node:internal/child_process:285:19)
    at onErrorNT (node:internal/child_process:485:16)
    at processTicksAndRejections (node:internal/process/task_queues:83:21)
    at process.<anonymous> (file:/// ... /node_modules/sst/cli/sst.js:58:17)
    at process.emit (node:events:525:35)
    at processEmit [as emit] (/ ... /node_modules/signal-exit/index.js:199:34)
    at process._fatalException (node:internal/process/execution:149:25)
```

I fixed it by changing the current working directory of `python3`