### PR TITLE
fix: send tags with deployment call

### DIFF
--- a/.changeset/odd-beds-bake.md
+++ b/.changeset/odd-beds-bake.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+fix: send tags with deployment call

--- a/packages/sst/src/stacks/deploy.ts
+++ b/packages/sst/src/stacks/deploy.ts
@@ -106,11 +106,14 @@ export async function deploy(
   const deployment = new CloudFormationDeployments({
     sdkProvider: provider,
   });
+  const stackTags = Object.entries(stack.tags ?? {})
+    .map(([Key, Value]) => ({ Key, Value }));
   try {
     await addInUseExports(stack);
     const result = await deployment.deployStack({
       stack: stack as any,
       quiet: true,
+      tags: stackTags,
       deploymentMethod: {
         method: "direct",
       },


### PR DESCRIPTION
The CDK/CF API sends tags via multiple means. As part of resource constructs that support tags, as metadata, but also importantly as part of the API call itself.

With the v2 changes, SST is not sending tags as part of the API call breaking assumptions and controls around that API.

This restores that behavior.