### PR TITLE
Python Runtime: Don't copy SST directory

### DIFF
--- a/.changeset/plenty-steaks-divide.md
+++ b/.changeset/plenty-steaks-divide.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+Python Runtime: Don't copy SST directory

--- a/packages/sst/src/runtime/handlers/python.ts
+++ b/packages/sst/src/runtime/handlers/python.ts
@@ -87,6 +87,7 @@ export const usePythonHandler = Context.memo(async () => {
       const src = await findAbove(input.props.handler!, "requirements.txt");
       await fs.cp(src, input.out, {
         recursive: true,
+        filter: (src) => !src.includes(".sst"),
       });
 
       if (input.props.python?.installCommands) {


### PR DESCRIPTION
Resolves #2469