### PR TITLE
fix: allow empty identity

### DIFF
--- a/packages/sst/support/python-runtime/runtime.py
+++ b/packages/sst/support/python-runtime/runtime.py
@@ -74,7 +74,7 @@ if __name__ == '__main__':
         r.getheader('Lambda-Runtime-Invoked-Function-Arn'),
         r.getheader('Lambda-Runtime-Aws-Request-Id'),
         r.getheader('Lambda-Runtime-Deadline-Ms'),
-        r.getheader('Lambda-Runtime-Cognito-Identity'),
+        r.getheader('Lambda-Runtime-Cognito-Identity') or '{}',
         r.getheader('Lambda-Runtime-Client-Context')
     )
 


### PR DESCRIPTION
Just did a fresh python quickstart `npx create-sst@latest . --template=other/python`, then when doing `npm run dev`, I saw a python error about this. This header is missing when clicking on the endpoint given and checking all the headers.

```
|  Invoked functions/lambda.handler
|  +545ms  Traceback (most recent call last):
|  +545ms    File "/app/node_modules/sst/support/python-runtime/runtime.py", line 73, in <module>
|  +545ms      context = Context(
|  +545ms    File "/app/node_modules/sst/support/python-runtime/runtime.py", line 30, in __init__
|  +545ms      self.identity = Identity(**json.loads(identity))
|  +545ms    File "/.pyenv/versions/3.10.2/lib/python3.10/json/__init__.py", line 339, in loads
|  +547ms  raise TypeError(f'the JSON object must be str, bytes or bytearray, '
|  +547ms  TypeError: the JSON object must be str, bytes or bytearray, not NoneType
|  Invoked functions/lambda.handler
```