### PR TITLE
Docs: replaced 'nodeModules' with 'install' in Function

### DIFF
--- a/packages/sst/src/constructs/Function.ts
+++ b/packages/sst/src/constructs/Function.ts
@@ -411,7 +411,7 @@ export interface NodeJSProps {
    * ```js
    * new Function(stack, "Function", {
    *   nodejs: {
-   *     nodeModules: ["pg"]
+   *     install: ["pg"]
    *   }
    * })
    * ```


### PR DESCRIPTION
Replaced 'nodeModules' with 'install' in NodeJSProps. Updated documentation to reflect typings.