### PR TITLE
fix: NextjsSite allow rsc headers for in-place routing

### DIFF
--- a/.changeset/green-parrots-pretend.md
+++ b/.changeset/green-parrots-pretend.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+NextjsSite: allow rsc headers for in-place routing

--- a/packages/sst/src/constructs/NextjsSite.ts
+++ b/packages/sst/src/constructs/NextjsSite.ts
@@ -282,6 +282,8 @@ export class NextjsSite extends SsrSite {
       headerBehavior: cloudfront.CacheHeaderBehavior.allowList(
         // required by image optimization request
         "accept",
+        // required by middleware for <Link /> routing in place
+        "rsc",
         // required by server request
         "x-op-middleware-request-headers",
         "x-op-middleware-response-headers",

--- a/packages/sst/src/constructs/NextjsSite.ts
+++ b/packages/sst/src/constructs/NextjsSite.ts
@@ -282,8 +282,8 @@ export class NextjsSite extends SsrSite {
       headerBehavior: cloudfront.CacheHeaderBehavior.allowList(
         // required by image optimization request
         "accept",
-        // required by middleware for <Link /> routing in place
-        "rsc",
+        // required by middleware for routing in place
+        "rsc", "next-router-prefetch", "next-router-state-tree",
         // required by server request
         "x-op-middleware-request-headers",
         "x-op-middleware-response-headers",

--- a/packages/sst/src/constructs/NextjsSite.ts
+++ b/packages/sst/src/constructs/NextjsSite.ts
@@ -282,7 +282,9 @@ export class NextjsSite extends SsrSite {
       headerBehavior: cloudfront.CacheHeaderBehavior.allowList(
         // required by image optimization request
         "accept",
-        // required by middleware for routing in place
+        // required by middleware for routing in place; see: https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/app-router-headers.ts#L8
+        // rsc = React Server Component, with next-router-<prefetch,state-tree> - it tells next-server to prefetch the routes
+        // with its relevant chunk assets to load
         "rsc", "next-router-prefetch", "next-router-state-tree",
         // required by server request
         "x-op-middleware-request-headers",

--- a/packages/sst/src/constructs/NextjsSite.ts
+++ b/packages/sst/src/constructs/NextjsSite.ts
@@ -282,15 +282,15 @@ export class NextjsSite extends SsrSite {
       headerBehavior: cloudfront.CacheHeaderBehavior.allowList(
         // required by image optimization request
         "accept",
-        // required by middleware for routing in place; see: https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/app-router-headers.ts#L8
-        // rsc = React Server Component, with next-router-<prefetch,state-tree> - it tells next-server to prefetch the routes
-        // with its relevant chunk assets to load
-        "rsc", "next-router-prefetch", "next-router-state-tree",
         // required by server request
         "x-op-middleware-request-headers",
         "x-op-middleware-response-headers",
         "x-nextjs-data",
-        "x-middleware-prefetch"
+        "x-middleware-prefetch",
+        // required by server request (in-place routing)
+        "rsc",
+        "next-router-prefetch",
+        "next-router-state-tree"
       ),
       cookieBehavior: cloudfront.CacheCookieBehavior.all(),
       defaultTtl: CdkDuration.days(0),


### PR DESCRIPTION
Issue: NextjsSite application router navigations were hard refreshing the page instead of routing in place.

Fix: router navigations now happen in-place without a full page reload.

NOTE: very small change but took a long time to figure out what was missing.