### PR TITLE
fix: CLI throws error, when committing MFA on Node18

### DIFF
--- a/.changeset/pretty-bags-crash.md
+++ b/.changeset/pretty-bags-crash.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+fix: CLI hrows error, when committing MFA on Node18

--- a/packages/sst/src/credentials.ts
+++ b/packages/sst/src/credentials.ts
@@ -34,9 +34,10 @@ export const useAWSCredentialsProvider = Context.memo(() => {
             if (input.trim() !== "") {
               resolve(input.trim());
               rl.close();
+            } else {
+              // prompt again if no input
+              prompt();
             }
-            // prompt again if no input
-            prompt();
           });
         prompt();
       });


### PR DESCRIPTION
Related Issue: https://github.com/serverless-stack/sst/issues/2500

Fixes MFA input running on node18:
```
Enter MFA code for arn:aws:iam::xxxxx xxxx
Error: readline was closed

Trace: Error [ERR_USE_AFTER_CLOSE]: readline was closed
    at __node_internal_captureLargerStackTrace (node:internal/errors:490:5)
    at new NodeError (node:internal/errors:399:5)
    at Interface.question (node:internal/readline/interface:403:13)
    at Interface.question (node:readline:159:5)
    at prompt (file:///Users/uwilken/dev/campaign.delivery/sst/node_modules/.pnpm/sst@2.0.23/node_modules/sst/credentials.js:22:41)
    at file:///Users/uwilken/dev/campaign.delivery/sst/node_modules/.pnpm/sst@2.0.23/node_modules/sst/credentials.js:28:21
```
