### PR TITLE
Project: Fix .env.<stage>.local is not loaded

### DIFF
--- a/.changeset/fuzzy-terms-raise.md
+++ b/.changeset/fuzzy-terms-raise.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+Project: Fix .env.<stage>.local is not loaded

--- a/packages/sst/src/project.ts
+++ b/packages/sst/src/project.ts
@@ -143,6 +143,10 @@ export async function initProject(globals: GlobalOptions) {
     path: path.join(project.paths.root, `.env.${project.config.stage}`),
     override: true,
   });
+  dotenv.config({
+    path: path.join(project.paths.root, `.env.${project.config.stage}.local`),
+    override: true,
+  });
 
   Logger.debug("Config loaded", project);
 }


### PR DESCRIPTION
Related issue: #2397

Fix the pattern of `.env.{stageName}.local` was not read among the `.env` files listed in [Types of .env files](https://docs.sst.dev/config#types-of-env-files).