### PR TITLE
fix: add s3 perms to image opt lambda

### DIFF
--- a/.changeset/stale-mangos-burn.md
+++ b/.changeset/stale-mangos-burn.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+NextjsSite: fix image optimization lambda does not have s3 permission

--- a/packages/sst/src/constructs/NextjsSite.ts
+++ b/packages/sst/src/constructs/NextjsSite.ts
@@ -84,7 +84,7 @@ export class NextjsSite extends SsrSite {
   private createImageOptimizationFunctionForRegional(): lambda.Function {
     const { imageOptimization, path: sitePath } = this.props;
 
-    const fn = new lambda.Function(this, `ImageFunction`, {
+    return new lambda.Function(this, `ImageFunction`, {
       description: "Image optimization handler for Next.js",
       handler: "index.handler",
       currentVersionOptions: {
@@ -105,15 +105,13 @@ export class NextjsSite extends SsrSite {
       environment: {
         BUCKET_NAME: this.cdk.bucket.bucketName,
       },
+      initialPolicy: [
+        new PolicyStatement({
+          actions: ["s3:GetObject"],
+          resources: [this.cdk.bucket.arnForObjects("*")],
+        }),
+      ],
     });
-    fn.role?.attachInlinePolicy(new Policy(this, 'image-opt-policy', {
-      statements: [new PolicyStatement({
-        actions: ['s3:GetObject'],
-        resources: [this.cdk.bucket.arnForObjects('*')]
-      })]
-    }));
-
-    return fn;
   }
 
   private createMiddlewareEdgeFunctionForRegional() {


### PR DESCRIPTION
fixes #2517

`sst` 2.0.28 removed public access from the S3 bucket. But AWS doesn't allow access w/in internal lambdas w/o explicit roles.