### PR TITLE
Fix dev mode in GovCloud (SSTv2)

### DIFF
--- a/.changeset/modern-llamas-drive.md
+++ b/.changeset/modern-llamas-drive.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+Fix dev mode in GovCloud (SSTv2)

--- a/packages/sst/src/bootstrap.ts
+++ b/packages/sst/src/bootstrap.ts
@@ -148,7 +148,7 @@ export async function bootstrapSST(tags: Record<string, string>) {
       path.resolve(__dirname, "support/bootstrap-metadata-function")
     ),
     handler: "index.handler",
-    runtime: app.region?.startsWith("us-gov-")
+    runtime: project.config.region?.startsWith("us-gov-")
       ? Runtime.NODEJS_16_X
       : Runtime.NODEJS_18_X,
     environment: {

--- a/packages/sst/support/bridge/bridge.ts
+++ b/packages/sst/support/bridge/bridge.ts
@@ -53,6 +53,7 @@ const ENVIRONMENT = Object.fromEntries(
 const device = new iot.device({
   protocol: "wss",
   host: endpoint,
+  region: ENVIRONMENT.AWS_REGION,
 });
 device.on("error", console.log);
 device.on("connect", console.log);


### PR DESCRIPTION
From Discord: https://discord.com/channels/983865673656705025/1077267922659061882

There are currently 2 issues affecting dev mode and deployment to GovCloud as of v2.0.35:
- The bootstrap stack uses the Node 18.x runtime (not supported in GovCloud yet) despite the change in [776fb8f](https://github.com/serverless-stack/sst/commit/776fb8f269ab20c574fb7e365bffbb88d30d4a60) because `app.region` appears to be undefined at the point it is used. This PR uses `project.config.region` instead.
- The AWS IoT SDK for JavaScript has an issue that incorrectly parses IoT endpoints that contain regions with 4 segments, like `us-gov-west-1`. The workaround for this issue is to provide a region explicitly. This was done for the client side in [531310c](https://github.com/serverless-stack/sst/commit/531310c1cc2e9fd26d33b20eac07a953f7e70396); this PR fixes the same issue on the AWS side in `packages/sst/support/bridge/bridge.ts`.