### PR TITLE
Docs: Add Dotnet Core Minimal API Example

### DIFF
--- a/packages/create-sst/bin/presets/examples/rest-api-dotnet-minimal/preset.mjs
+++ b/packages/create-sst/bin/presets/examples/rest-api-dotnet-minimal/preset.mjs
@@ -1,0 +1,3 @@
+import { extend, extract, install } from "create-sst";
+
+export default [extend("presets/base/example"), extract()];

--- a/packages/create-sst/bin/presets/examples/rest-api-dotnet-minimal/templates/Readme.md
+++ b/packages/create-sst/bin/presets/examples/rest-api-dotnet-minimal/templates/Readme.md
@@ -1,0 +1,23 @@
+# ASP.NET Core Minimal API Serverless Application
+
+This project shows how to run an ASP.NET Core Web Minimal API project as an AWS Lambda exposed through an HTTP Amazon API Gateway using SST. The NuGet package [Amazon.Lambda.AspNetCoreServer](https://www.nuget.org/packages/Amazon.Lambda.AspNetCoreServer) contains a Lambda function that is used to translate requests from API Gateway into the ASP.NET Core framework and then the responses from ASP.NET Core back to API Gateway.
+
+
+For more information about how the Amazon.Lambda.AspNetCoreServer package works and how to extend its behavior view its [README](https://github.com/aws/aws-lambda-dotnet/blob/master/Libraries/src/Amazon.Lambda.AspNetCoreServer/README.md) file in GitHub.
+
+## Executable Assembly ##
+
+.NET Lambda projects that use C# top level statements like this project must be deployed as an executable assembly instead of a class library. To indicate to Lambda that the .NET function is an executable assembly the 
+Lambda function handler value is set to the .NET Assembly name. This is different then deploying as a class library where the function handler string includes the assembly, type and method name.
+
+To deploy as an executable assembly the Lambda runtime client must be started to listen for incoming events to process. For an ASP.NET Core application the Lambda runtime client is started by included the
+`Amazon.Lambda.AspNetCoreServer.Hosting` NuGet package and calling `AddAWSLambdaHosting(LambdaEventSource.HttpApi)` passing in the event source while configuring the services of the application. 
+
+### Project Files ###
+
+* runtimeconfig.template.json - the config file is important for providing build time instructions necessary for the lambda to packaged correctly. Without this file, the deployment may succeed but the lambda may fail to execute.
+* aws-lambda-tools-defaults.json - default argument settings for use with Visual Studio and command line deployment tools for AWS
+* Program.cs - entry point to the application that contains all of the top level statements initializing the ASP.NET Core application.
+The call to `AddAWSLambdaHosting` configures the application to work in Lambda when it detects Lambda is the executing environment. 
+* Controllers\CalculatorController - example Web API controller
+

--- a/packages/create-sst/bin/presets/examples/rest-api-dotnet-minimal/templates/packages/minimal-api/Controllers/CalculatorController.cs
+++ b/packages/create-sst/bin/presets/examples/rest-api-dotnet-minimal/templates/packages/minimal-api/Controllers/CalculatorController.cs
@@ -1,0 +1,38 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace packages.Controllers;
+
+[ApiController]
+[Route("[controller]")]
+public class CalculatorController : ControllerBase
+{
+    private readonly ILogger<CalculatorController> _logger;
+
+    public CalculatorController(ILogger<CalculatorController> logger)
+    {
+        _logger = logger;
+    }
+
+    public class CalculatorRequest
+    {
+        public int X { get; set; }
+        public int Y { get; set; }
+    }
+
+    /// <summary>
+    /// POST /calculator/add
+    /// Example Request body:
+    /// {
+    ///     "x": 1,
+    ///     "y": 2
+    /// }
+    /// Perform x + y
+    /// </summary>
+    /// <returns>Sum of x and y.</returns>
+    [HttpPost("add")]
+    public int Add([FromBody] CalculatorRequest request)
+    {
+        _logger.LogInformation($"{request.X} plus {request.Y} is {request.X + request.Y}");
+        return request.X + request.Y;
+    }
+}

--- a/packages/create-sst/bin/presets/examples/rest-api-dotnet-minimal/templates/packages/minimal-api/Program.cs
+++ b/packages/create-sst/bin/presets/examples/rest-api-dotnet-minimal/templates/packages/minimal-api/Program.cs
@@ -1,0 +1,20 @@
+var builder = WebApplication.CreateBuilder(args);
+
+// Add services to the container.
+builder.Services.AddControllers();
+
+// Add AWS Lambda support. When application is run in Lambda Kestrel is swapped out as the web server with Amazon.Lambda.AspNetCoreServer. This
+// package will act as the webserver translating request and responses between the Lambda event source and ASP.NET Core.
+// Must be an HTTP API to work when deployed to Lambda, RestApi will not work.
+builder.Services.AddAWSLambdaHosting(LambdaEventSource.HttpApi);
+
+var app = builder.Build();
+
+
+app.UseHttpsRedirection();
+app.UseAuthorization();
+app.MapControllers();
+
+app.MapGet("/", () => "Welcome to running ASP.NET Core Minimal API on AWS Lambda using SST");
+
+app.Run();

--- a/packages/create-sst/bin/presets/examples/rest-api-dotnet-minimal/templates/packages/minimal-api/Properties/launchSettings.json
+++ b/packages/create-sst/bin/presets/examples/rest-api-dotnet-minimal/templates/packages/minimal-api/Properties/launchSettings.json
@@ -1,0 +1,16 @@
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true
+  },
+  "profiles": {
+    "packages": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:52774",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/packages/create-sst/bin/presets/examples/rest-api-dotnet-minimal/templates/packages/minimal-api/appsettings.Development.json
+++ b/packages/create-sst/bin/presets/examples/rest-api-dotnet-minimal/templates/packages/minimal-api/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/packages/create-sst/bin/presets/examples/rest-api-dotnet-minimal/templates/packages/minimal-api/appsettings.json
+++ b/packages/create-sst/bin/presets/examples/rest-api-dotnet-minimal/templates/packages/minimal-api/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/packages/create-sst/bin/presets/examples/rest-api-dotnet-minimal/templates/packages/minimal-api/aws-lambda-tools-defaults.json
+++ b/packages/create-sst/bin/presets/examples/rest-api-dotnet-minimal/templates/packages/minimal-api/aws-lambda-tools-defaults.json
@@ -1,0 +1,14 @@
+{
+  "Information": [
+    "This file provides default values for the deployment wizard inside Visual Studio and the AWS Lambda commands added to the .NET Core CLI.",
+    "To learn more about the Lambda commands with the .NET Core CLI execute the following command at the command line in the project root directory.",
+    "dotnet lambda help",
+    "All the command line options for the Lambda command can be specified in this file."
+  ],
+  "profile": "",
+  "region": "",
+  "configuration": "Release",
+  "s3-prefix": "packages/",
+  "template": "serverless.template",
+  "template-parameters": ""
+}

--- a/packages/create-sst/bin/presets/examples/rest-api-dotnet-minimal/templates/packages/minimal-api/minimal-api.csproj
+++ b/packages/create-sst/bin/presets/examples/rest-api-dotnet-minimal/templates/packages/minimal-api/minimal-api.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <AWSProjectType>Lambda</AWSProjectType>
+    <!-- This property makes the build directory similar to a publish directory and helps the AWS .NET Lambda Mock Test Tool find project dependencies. -->
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <!-- Generate ready to run images during publishing to improvement cold starts. -->
+    <PublishReadyToRun>false</PublishReadyToRun>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(RunConfiguration)' == 'packages' " />
+  <ItemGroup>
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer.Hosting" Version="1.5.0" />
+  </ItemGroup>
+</Project>

--- a/packages/create-sst/bin/presets/examples/rest-api-dotnet-minimal/templates/packages/minimal-api/runtimeconfig.template.json
+++ b/packages/create-sst/bin/presets/examples/rest-api-dotnet-minimal/templates/packages/minimal-api/runtimeconfig.template.json
@@ -1,0 +1,19 @@
+{
+    "runtimeOptions": {
+        "tfm": "net6.0",
+        "frameworks": [
+            {
+                "name": "Microsoft.AspNetCore.App",
+                "version": "6.0.0"
+            },
+            {
+                "name": "Microsoft.NETCore.App",
+                "version": "6.0.0"
+            }
+        ],
+        "configProperties": {
+            "System.GC.Server": true,
+            "System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization": false
+        }
+    }
+}

--- a/packages/create-sst/bin/presets/examples/rest-api-dotnet-minimal/templates/stacks/ExampleStack.ts
+++ b/packages/create-sst/bin/presets/examples/rest-api-dotnet-minimal/templates/stacks/ExampleStack.ts
@@ -1,0 +1,18 @@
+import { StackContext, Api } from "sst/constructs";
+
+export function ExampleStack({ stack }: StackContext) {
+  const api = new Api(stack, "api", {
+    routes: {
+      $default: {
+        function: {
+          architecture: "arm_64",
+          handler: "minimal-api",
+          runtime: "dotnet6",
+        }
+      }
+    },
+  });
+  stack.addOutputs({
+    ApiEndpoint: api.url,
+  });
+}

--- a/www/docs/constructs/Function.about.md
+++ b/www/docs/constructs/Function.about.md
@@ -131,6 +131,23 @@ namespace Example
 
 The handler would be, `MyApp::Example.Hello::MyHandler`.
 
+#### .NET Minimal API
+
+When using an ASP.NET Core minimal API, the handler reference works differently, [read more about this here](https://docs.aws.amazon.com/lambda/latest/dg/csharp-handler.html) regarding projects using top-level statements such as minimal APIs.
+
+Consider a project with `MyApp.csproj` and the following handler function:
+
+```csharp
+using Amazon.Lambda.RuntimeSupport;
+var handler = (Stream stream) =>
+{
+  //function logic
+};
+await LambdaBootstrapBuilder.Create(handler).Build().RunAsync();
+```
+
+The handler would simply be, `MyApp`. As a result, you should avoid using the same name for your .NET projects regardless of the folder structure to avoid naming collisions.
+
 ### Configuring F#(.NET) runtime
 
 #### handler


### PR DESCRIPTION
ASP.NET Core Minimal APIs work a little differently than the standard C# API implementation so this adds an example and an update to the documentation on how to make this work with SST. Addresses https://github.com/serverless-stack/sst/issues/2124.