### PR TITLE
Update KyselyTypeGenerator to use the correct dialect based on db engine

### DIFF
--- a/.changeset/proud-peas-cover.md
+++ b/.changeset/proud-peas-cover.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+Update KyselyTypeGenerator to use the correct dialect based on db engine

--- a/packages/sst/src/cli/commands/plugins/kysely.ts
+++ b/packages/sst/src/cli/commands/plugins/kysely.ts
@@ -8,6 +8,7 @@ import {
   EnumCollection,
   ExportStatementNode,
   PostgresDialect,
+  MysqlDialect,
   Serializer,
   Transformer,
 } from "kysely-codegen";
@@ -80,8 +81,9 @@ export const useKyselyTypeGenerator = Context.memo(async () => {
         }));
 
     const transformer = new Transformer();
+    const Dialect = db.engine.includes("postgres") ? new PostgresDialect() : new MysqlDialect()
     const nodes = transformer.transform({
-      dialect: new PostgresDialect(),
+      dialect: Dialect,
       camelCase: (db.types.camelCase as any) === true,
       metadata: new DatabaseMetadata(metadata, new EnumCollection()),
     });


### PR DESCRIPTION
Fixes a bug that was causing incorrect types when using a mysql db engine.