### PR TITLE
Improve Python bundling speed

### DIFF
--- a/.changeset/nine-ghosts-leave.md
+++ b/.changeset/nine-ghosts-leave.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+Improve Python bundling speed


### PR DESCRIPTION
Discord thread: [https://discord.com/channels/983865673656705025/983866416832864350/1080155956815593532](https://discord.com/channels/983865673656705025/983866416832864350/1080155956815593532)

Docker is used to bundle Python functions since [13eb42c](https://github.com/serverless-stack/sst/commit/13eb42c041aceca3b221ae3fa60be21eea86e11a). This PR changes the way source code and dependencies are copied into the final bundle to speed up the bundling process:
- Dependencies are copied from the Docker container using `image.cp` instead of `rsync` inside the container.
- Source code is copied directly from the `entry` directory to the output directory **on the host** using `fs.cpSync` instead of `rsync` inside of the Docker container from one bind mount to another.

Here's a performance comparison between the versions. The comparison uses:
- A mid-spec MacBook Pro (2 GHz quad core i5 with 32 GB of RAM).
- A project that contains 13 Python lambda functions and uses Poetry as the package manager.

| Step               | Baseline | This PR |
|--------------------|----------|---------|
| Build Docker image | 0.27s    | 0.28s   |
| Copy dependencies  | 112.62s  | 9.46s   |
| Copy source        | 4.69s    | 0.32s   |

(This table represents per-function bundle times, so the total amount of time to bundle a function is the sum of the values in a column)
