### PR TITLE
Use posix seperator when deploying python lambda

### DIFF
--- a/.changeset/loud-ears-join.md
+++ b/.changeset/loud-ears-join.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+Use posix seperator when deploying python lambda

--- a/packages/sst/src/runtime/handlers/python.ts
+++ b/packages/sst/src/runtime/handlers/python.ts
@@ -144,7 +144,10 @@ export const usePythonHandler = Context.memo(async () => {
 
       return {
         type: "success",
-        handler: path.relative(src, path.resolve(input.props.handler!)),
+        handler: path
+          .relative(src, path.resolve(input.props.handler!))
+          .split(path.sep)
+          .join(path.posix.sep),
       };
     },
   });


### PR DESCRIPTION
Related Issue:
#2581 