### PR TITLE
Remove unusable cognitoIdentityId from log format

### DIFF
--- a/.changeset/modern-cycles-pay.md
+++ b/.changeset/modern-cycles-pay.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+Remove unusable cognitoIdentityId from log format

--- a/packages/sst/src/constructs/util/apiGatewayV2AccessLog.ts
+++ b/packages/sst/src/constructs/util/apiGatewayV2AccessLog.ts
@@ -26,8 +26,7 @@ const defaultHttpFields = [
   `"integrationServiceStatus":"$context.integration.integrationStatus"`,
   // caller info
   `"ip":"$context.identity.sourceIp"`,
-  `"userAgent":"$context.identity.userAgent"`,
-  `"cognitoIdentityId":"$context.identity.cognitoIdentityId"`,
+  `"userAgent":"$context.identity.userAgent"`
 ];
 
 const defaultWebSocketFields = [
@@ -45,7 +44,6 @@ const defaultWebSocketFields = [
   // caller info
   `"ip":"$context.identity.sourceIp"`,
   `"userAgent":"$context.identity.userAgent"`,
-  `"cognitoIdentityId":"$context.identity.cognitoIdentityId"`,
   `"connectedAt":"$context.connectedAt"`,
   `"connectionId":"$context.connectionId"`,
 ];


### PR DESCRIPTION
It is not valid in HTTP APIs to use $context.identity.cognitoIdentityId in a log statement, as HTTP APIs do not support direct integration with Cognito. The AWS create-stage API was recently updated such that attempting to use $context.identity.cognitoIdentityId in a log format results in an error when creating a stage (currently only in us-west-2). It was never possible for $context.identity.cognitoIdentityId to work, and so removing it should be harmless.

Note the AWS docs on this are wrong. [This page](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-logging-variables.html) claims it's valid to use $context.identity.cognitoIdentityId, but [this page](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-vs-rest.html) makes it clear that HTTP APIs do not support direct Cognito integration.

Furthermore, the AWS Console makes it clear you cannot add a Cognito authorizer to an HTTP API (whereas you can to a REST API).

Resolves #2587