### PR TITLE
fix: only write package.json if changed

### DIFF
--- a/packages/sst/src/cli/commands/update.ts
+++ b/packages/sst/src/cli/commands/update.ts
@@ -76,7 +76,9 @@ export const update = (program: Program) =>
           }
         }
 
-        await fs.writeFile(file, JSON.stringify(data, null, 2));
+        if (results.has(file) {
+          await fs.writeFile(file, JSON.stringify(data, null, 2));
+        }
       });
       await Promise.all(tasks);
 


### PR DESCRIPTION
This avoids changing formatting of unaffected files.

Resolves: #2591 