### PR TITLE
Api: fix access log field "cognitoIdentityId" not supported in us-west-2

### DIFF
--- a/.changeset/healthy-squids-thank.md
+++ b/.changeset/healthy-squids-thank.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+Api: fix access log field "cognitoIdentityId" not supported in us-west-2

--- a/packages/sst/src/constructs/util/apiGatewayV2AccessLog.ts
+++ b/packages/sst/src/constructs/util/apiGatewayV2AccessLog.ts
@@ -27,7 +27,8 @@ const defaultHttpFields = [
   // caller info
   `"ip":"$context.identity.sourceIp"`,
   `"userAgent":"$context.identity.userAgent"`,
-  `"cognitoIdentityId":"$context.identity.cognitoIdentityId"`,
+  // `cognitoIdentityId` is not supported in us-west-2 region
+  //`"cognitoIdentityId":"$context.identity.cognitoIdentityId"`,
 ];
 
 const defaultWebSocketFields = [


### PR DESCRIPTION
Closes #2587 