### PR TITLE
sst/cli: sst update to also update astro-sst version

### DIFF
--- a/.changeset/three-coats-do.md
+++ b/.changeset/three-coats-do.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+`sst update` now also updates the version of `astro-sst`

--- a/packages/sst/src/cli/commands/update.ts
+++ b/packages/sst/src/cli/commands/update.ts
@@ -1,6 +1,6 @@
 import type { Program } from "../program.js";
 
-const PACKAGE_MATCH = ["sst", "aws-cdk", "@aws-cdk", "constructs"];
+const PACKAGE_MATCH = ["sst", "astro-sst", "aws-cdk", "@aws-cdk", "constructs"];
 
 const FIELDS = ["dependencies", "devDependencies"];
 
@@ -59,7 +59,8 @@ export const update = (program: Program) =>
           for (const [pkg, existing] of Object.entries(deps)) {
             if (!PACKAGE_MATCH.some((x) => pkg.startsWith(x))) continue;
             const desired = (() => {
-              if (pkg === "sst") return metadata.version;
+              // Both sst and astro-sst should be sharing the same version
+              if (["sst", "astro-sst"].includes(pkg)) return metadata.version;
               if (pkg === "constructs") return metadata.dependencies.constructs;
               if (pkg.endsWith("alpha"))
                 return metadata.dependencies["@aws-cdk/aws-apigatewayv2-alpha"];


### PR DESCRIPTION
This improves `sst update` to also update the version of `astro-sst` which shares the same version number as `sst` package.