### PR TITLE
bug: remove shell parameter from env cli

### DIFF
--- a/.changeset/young-ducks-deny.md
+++ b/.changeset/young-ducks-deny.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+bug: remove shell parameter when spawning sub-processes

--- a/packages/sst/src/bootstrap.ts
+++ b/packages/sst/src/bootstrap.ts
@@ -240,7 +240,7 @@ async function bootstrapCDK() {
           AWS_PROFILE: profile,
         },
         stdio: "pipe",
-        shell: process.env.SHELL || true,
+        shell: true,
       }
     );
     let stderr = "";

--- a/packages/sst/src/cli/commands/bind.ts
+++ b/packages/sst/src/cli/commands/bind.ts
@@ -36,7 +36,7 @@ export const bind = (program: Program) =>
             AWS_REGION: project.config.region,
           },
           stdio: "inherit",
-          shell: process.env.SHELL || true,
+          shell: true,
         });
         process.exitCode = result.status || undefined;
       }

--- a/packages/sst/src/cli/commands/env.ts
+++ b/packages/sst/src/cli/commands/env.ts
@@ -59,7 +59,7 @@ export const env = (program: Program) =>
               AWS_REGION: project.config.region,
             },
             stdio: "inherit",
-            shell: process.env.SHELL || true,
+            shell: true,
           });
           process.exitCode = result.status || undefined;
 


### PR DESCRIPTION
As per discussion [on discord](https://discord.com/channels/983865673656705025/1073321613589753968/1073334256765509722), I need this change in order for the env cli command to work properly on Cygwin.

Dax mentioned that he may push this himself but I haven't seen the change come in and I keep having to edit the file myself whenever I pull down new code.