### PR TITLE
Fixed local lambda runtime having access to local env variables

### DIFF
--- a/.changeset/real-pets-mix.md
+++ b/.changeset/real-pets-mix.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+Fixed local lambda runtime having access to local env variables

--- a/packages/sst/src/runtime/handlers/node.ts
+++ b/packages/sst/src/runtime/handlers/node.ts
@@ -38,7 +38,6 @@ export const useNodeHandler = Context.memo(async () => {
           ),
           {
             env: {
-              ...process.env,
               ...input.environment,
               IS_LOCAL: "true",
             },


### PR DESCRIPTION
Removed `process.env` being merged to local lambda.

### Rationale

When running lambda in `dev` mode, we should try to mimick the real AWS Lambda environment. By merging in local env variables, we give access to local variables that won't be available when deploying final code to Lambda.

### The problem

The problem I encountered appeared after upgrading to v2.  I noticed, that I didn't have to give my lambda any permissions and it would still execute successfully. What I have found out, was that yes, the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` were correctly set.

But, that is when I noticed, that my lambda also had access to `AWS_PROFILE`, which was linking to my `~/.aws/credentials` file. 

### Other possible solutions

- Overwrite `AWS_PROFILE` setting it to the one coming from lambda,
- State in the docs that local env variables leak to the code when using `dev`.