### PR TITLE
fix: Future Auth should redirect to port 3000 instead of 300

### DIFF
--- a/.changeset/hungry-clouds-heal.md
+++ b/.changeset/hungry-clouds-heal.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+Updated the return page to have a table with all of the clients and input providers

--- a/.changeset/pretty-ligers-compete.md
+++ b/.changeset/pretty-ligers-compete.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+Fixed future Auth redirection to go to port 3000 instead of 300

--- a/packages/sst/src/node/future/auth/handler.ts
+++ b/packages/sst/src/node/future/auth/handler.ts
@@ -48,7 +48,7 @@ export function AuthHandler<
           <html>
             <body>
             ${Object.keys(input.providers).map((name) => {
-              return `<a href="/authorize?provider=${name}&response_type=code&client_id=local&redirect_uri=http://localhost:300">${name}</a>`;
+              return `<a href="/authorize?provider=${name}&response_type=code&client_id=local&redirect_uri=http://localhost:3000">${name}</a>`;
             })}
             </body>
           </html>

--- a/packages/sst/src/node/future/auth/handler.ts
+++ b/packages/sst/src/node/future/auth/handler.ts
@@ -39,6 +39,7 @@ export function AuthHandler<
   return ApiHandler(async (evt) => {
     const step = usePathParam("step");
     if (!step) {
+      const clients = await input.clients();
       return {
         statusCode: 200,
         headers: {
@@ -47,9 +48,19 @@ export function AuthHandler<
         body: `
           <html>
             <body>
+            <table>
+              <tr>${Object.keys(clients).map(
+                (client) => `<td>${client}</td>`
+              )}</tr>
             ${Object.keys(input.providers).map((name) => {
-              return `<a href="/authorize?provider=${name}&response_type=code&client_id=local&redirect_uri=http://localhost:3000">${name}</a>`;
+              return `<tr>
+                ${Object.keys(clients).map((client_id) => {
+                  const redirect_uri = clients[client_id];
+                  return `<td><a href="/authorize?provider=${name}&response_type=token&client_id=${client_id}&redirect_uri=${redirect_uri}">${name} - ${client_id}</a></td>`;
+                })}
+              </tr>`;
             })}
+            </table>
             </body>
           </html>
         `,


### PR DESCRIPTION
The link on the base auth page is redirecting to port 300 instead of 3000. Missing a zero. Just fixes this. Later on maybe should be using a config instead.