### PR TITLE
chore: exported the adapter type for future auth

### DIFF
--- a/.changeset/tall-fans-fix.md
+++ b/.changeset/tall-fans-fix.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+Exported the Adapter type for future auth, so others can create their own custom adapters

--- a/packages/sst/src/node/future/auth/index.ts
+++ b/packages/sst/src/node/future/auth/index.ts
@@ -10,6 +10,7 @@ export * from "./adapter/google.js";
 export * from "./adapter/link.js";
 export * from "./adapter/github.js";
 export * from "./adapter/oauth.js";
+export type { Adapter } from "./adapter/adapter.js";
 
 export * from "./session.js";
 export * from "./handler.js";


### PR DESCRIPTION
Exported the Adapter type for future auth, so others can create their own custom adapters that satisfies the same type as required.