### PR TITLE
fix: localstorage.removeItem rather than clear

### DIFF
--- a/packages/create-sst/bin/presets/examples/api-sst-auth-facebook/templates/web/src/App.jsx
+++ b/packages/create-sst/bin/presets/examples/api-sst-auth-facebook/templates/web/src/App.jsx
@@ -45,7 +45,7 @@ const App = () => {
   };
 
   const signOut = async () => {
-    localStorage.clear("session");
+    localStorage.removeItem("session");
     setSession(null);
   };
 

--- a/packages/create-sst/bin/presets/examples/api-sst-auth-google/templates/web/src/App.jsx
+++ b/packages/create-sst/bin/presets/examples/api-sst-auth-google/templates/web/src/App.jsx
@@ -45,7 +45,7 @@ const App = () => {
   };
 
   const signOut = async () => {
-    localStorage.clear("session");
+    localStorage.removeItem("session");
     setSession(null);
   };
 


### PR DESCRIPTION
While working through auth I noticed that this was clearing with an argument. What it should actually do is remove the item that's set previously. 

You can see the docs here:
https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage#examples

There's [another PR here](https://github.com/AnomalyInnovations/serverless-stack-com/pull/703) for `serverless-stack-com`