### PR TITLE
Adds archiver package to deps for sst-cdk forked package

### DIFF
--- a/.github/workflows/aws-cdk.yml
+++ b/.github/workflows/aws-cdk.yml
@@ -42,7 +42,7 @@ jobs:
           PACKAGE_JSON=./package/package.json
           VERSION=$(jq -r .version $PACKAGE_JSON)
           jq '
-            .dependencies += {chalk: .devDependencies.chalk, yaml: .devDependencies.yaml, promptly: .devDependencies.promptly} |
+            .dependencies += {chalk: .devDependencies.chalk, yaml: .devDependencies.yaml, promptly: .devDependencies.promptly, archiver: .devDependencies.archiver } |
             .name = "sst-aws-cdk"
           ' $PACKAGE_JSON > tmp.json
           mv tmp.json $PACKAGE_JSON


### PR DESCRIPTION
The archiver package is a aws-cdk dependency that gets converted to a dev dependency and causes sst errors. This adds it back as a dependency.

fixes #2681