### PR TITLE
sst/future/auth: added FB Adapter

### DIFF
--- a/.changeset/light-llamas-dream.md
+++ b/.changeset/light-llamas-dream.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+Added Facebook Adapter into future auth

--- a/packages/sst/src/node/future/auth/adapter/facebook.ts
+++ b/packages/sst/src/node/future/auth/adapter/facebook.ts
@@ -1,0 +1,30 @@
+import { Issuer } from "openid-client";
+import { OauthAdapter, OauthBasicConfig } from "./oauth.js";
+
+// Facebook's OIDC flow returns "id_token" as uri hash in redirect uri. Hashes
+// are not passed to Lambda event object. It is likely that Facebook only wants
+// to support redirecting to a frontend uri.
+//
+// We are only going to support the OAuth flow for now. More details about the flow:
+// https://developers.facebook.com/docs/facebook-login/guides/advanced/oidc-token
+//
+// Also note that Facebook's discover uri does not work for the OAuth flow, as the
+// token_endpoint and userinfo_endpoint are not included in the response.
+// await Issuer.discover("https://www.facebook.com/.well-known/openid-configuration/");
+
+const issuer = new Issuer({
+  issuer: "https://www.facebook.com",
+  authorization_endpoint: "https://facebook.com/dialog/oauth/",
+  jwks_uri: "https://www.facebook.com/.well-known/oauth/openid/jwks/",
+  token_endpoint: "https://graph.facebook.com/oauth/access_token",
+  userinfo_endpoint: "https://graph.facebook.com/oauth/access_token",
+});
+
+export const FacebookAdapter =
+  /* @__PURE__ */
+  (config: OauthBasicConfig) => {
+    return OauthAdapter({
+      issuer,
+      ...config,
+    });
+  };

--- a/packages/sst/src/node/future/auth/index.ts
+++ b/packages/sst/src/node/future/auth/index.ts
@@ -9,6 +9,7 @@ export * from "./adapter/oidc.js";
 export * from "./adapter/google.js";
 export * from "./adapter/link.js";
 export * from "./adapter/github.js";
+export * from "./adapter/facebook.js";
 export * from "./adapter/oauth.js";
 export type { Adapter } from "./adapter/adapter.js";
 


### PR DESCRIPTION
FB Adapter was missing from future auth, so just added it in. Copied from the current one and adjusted to suit the new adapter.