### PR TITLE
fix: Fix top level await error

### DIFF
--- a/packages/sst/src/node/util/index.ts
+++ b/packages/sst/src/node/util/index.ts
@@ -14,7 +14,9 @@ const ssm = new SSMClient({ region: process.env.SST_REGION });
 //   }
 // }
 let allVariables: Record<string, Record<string, Record<string, string>>> = {};
-await parseEnvironment();
+// NOTE: top level await must be assigned to a variable, otherwise it would
+//       throw a top level await error.
+const env = await parseEnvironment();
 
 interface Variable {
   constructName: string;


### PR DESCRIPTION
Unassigned `await` throws error - don't ask me why.