### PR TITLE
fix: remove ReactStaticSite leftover

### DIFF
--- a/www/docs/clients/site.md
+++ b/www/docs/clients/site.md
@@ -38,18 +38,6 @@ console.log(StaticSite.myWeb.url);
 
 ---
 
-#### url
-
-_Type_ : <span class="mono">string</span>
-
-The URL of the site. If custom domain is enabled, this is the custom domain URL of the site.
-
-```ts
-console.log(ReactStaticSite.myWeb.url);
-```
-
----
-
 ### NextjsSite
 
 This module helps with accessing [`NextjsSite`](../constructs/NextjsSite.md) constructs.


### PR DESCRIPTION
Hello 👋🏼 ,
The url part of the StaticSite client docs is duplicated, it's a leftover from an old ReactStaticSite construct. It seems like it wasn't completely removed during the V2 overhaul. This PR removes the duplicated mention 😃 

Screenshot of how this looks currently:

<img width="990" alt="image" src="https://user-images.githubusercontent.com/54995479/229719728-2adfe229-cb7b-43c8-b72c-5e47efbdbf03.png">

https://docs.sst.dev/clients/site
