### PR TITLE
fix solid start globals import

### DIFF
--- a/.changeset/unlucky-hornets-stare.md
+++ b/.changeset/unlucky-hornets-stare.md
@@ -1,0 +1,5 @@
+---
+"solid-start-sst": patch
+---
+
+fix solid start globals import

--- a/packages/solid-start-sst/entry-edge.mjs
+++ b/packages/solid-start-sst/entry-edge.mjs
@@ -1,4 +1,4 @@
-import "solid-start/node/globals";
+import "solid-start/node/globals.js";
 import manifest from "../../dist/client/route-manifest.json";
 import server from "./entry-server";
 

--- a/packages/solid-start-sst/entry.mjs
+++ b/packages/solid-start-sst/entry.mjs
@@ -1,4 +1,4 @@
-import "solid-start/node/globals";
+import "solid-start/node/globals.js";
 import manifest from "../../dist/client/route-manifest.json";
 import server from "./entry-server";
 


### PR DESCRIPTION
fix(imports): update the import to reference .js

This resolves the issue discussed here: https://discord.com/channels/983865673656705025/1092771219381686312

On build the `solid-start-sst` adapter imports `solid-start/node/globals` but I assume this can not be found because of the CJS/MJS mismatch? Stack trace:

```bash
node:internal/process/promises:288
            triggerUncaughtException(err, true /* fromPromise */);
            ^

[Error: Could not load /Users/alistairstead/code/saas/main/node_modules/.pnpm/solid-start@0.2.26_@solidjs+meta@0.28.4_@solidjs+router@0.8.2_solid-js@1.7.2_solid-start-node@0.2.26_vite@4.2.1/node_modules/solid-start/node/globals (imported by .solid/server/index.mjs): ENOENT: no such file or directory, open '/Users/alistairstead/code/saas/main/node_modules/.pnpm/solid-start@0.2.26_@solidjs+meta@0.28.4_@solidjs+router@0.8.2_solid-js@1.7.2_solid-start-node@0.2.26_vite@4.2.1/node_modules/solid-start/node/globals'] {
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: '/Users/alistairstead/code/saas/main/node_modules/.pnpm/solid-start@0.2.26_@solidjs+meta@0.28.4_@solidjs+router@0.8.2_solid-js@1.7.2_solid-start-node@0.2.26_vite@4.2.1/node_modules/solid-start/node/globals',
  watchFiles: [
    '/Users/alistairstead/code/saas/main/packages/admin/.solid/server/index.mjs',
    '/Users/alistairstead/code/saas/main/node_modules/.pnpm/solid-start@0.2.26_@solidjs+meta@0.28.4_@solidjs+router@0.8.2_solid-js@1.7.2_solid-start-node@0.2.26_vite@4.2.1/node_modules/solid-start/node/globals',
    '/Users/alistairstead/code/saas/main/packages/admin/dist/client/route-manifest.json'
  ]
}
```

Adding the file extension resolves the issue.