### PR TITLE
solid start resources

### DIFF
--- a/packages/sst/src/node/site/index.ts
+++ b/packages/sst/src/node/site/index.ts
@@ -5,6 +5,7 @@ export interface ReactStaticSiteResources {}
 export interface ViteStaticSiteResources {}
 export interface NextjsSiteResources {}
 export interface RemixSiteResources {}
+export interface SolidStartSiteResources {}
 
 export const StaticSite = createProxy<StaticSiteResources>("StaticSite");
 export const ReactStaticSite =
@@ -13,13 +14,17 @@ export const ViteStaticSite =
   createProxy<ViteStaticSiteResources>("ViteStaticSite");
 export const RemixSite = createProxy<RemixSiteResources>("RemixSite");
 export const NextjsSite = createProxy<NextjsSiteResources>("NextjsSite");
+export const SolidStartSite =
+  createProxy<SolidStartSiteResources>("SolidStartSite");
 const staticSiteData = getVariables("StaticSite");
 const reactSiteData = getVariables("ReactStaticSite");
 const viteSiteData = getVariables("ViteStaticSite");
 const nextjsSiteData = getVariables("NextjsSite");
 const remixSiteData = getVariables("RemixSite");
+const solidStartSiteData = getVariables("SolidStartSite");
 Object.assign(StaticSite, staticSiteData);
 Object.assign(ReactStaticSite, reactSiteData);
 Object.assign(ViteStaticSite, viteSiteData);
 Object.assign(NextjsSite, nextjsSiteData);
 Object.assign(RemixSite, remixSiteData);
+Object.assign(SolidStartSite, solidStartSiteData);


### PR DESCRIPTION
feat(solid-start): add the missing interface to access bound resources

When using the SolidStartSite it generates the types into .sst in this interface:

```
declare module "sst/node/site" {
  export interface SolidStartSiteResources {
    "Adminsite": {
      url: string;
    }
  }
}
```

However, the interface is not exposed in `sst/node/site` I have added the required const and interface definition.
