### PR TITLE
Add solid-start-sst to list of packages to update in command

### DIFF
--- a/packages/sst/src/cli/commands/update.ts
+++ b/packages/sst/src/cli/commands/update.ts
@@ -1,6 +1,13 @@
 import type { Program } from "../program.js";
 
-const PACKAGE_MATCH = ["sst", "astro-sst", "aws-cdk", "@aws-cdk", "constructs"];
+const PACKAGE_MATCH = [
+  "sst",
+  "astro-sst",
+  "aws-cdk",
+  "@aws-cdk",
+  "constructs",
+  "solid-start-sst",
+];
 
 const FIELDS = ["dependencies", "devDependencies"];
 


### PR DESCRIPTION
Update the `sst update` command to also update the `solid-start-sst` package
