### PR TITLE
Add support for relative python imports

### DIFF
--- a/.changeset/new-steaks-marry.md
+++ b/.changeset/new-steaks-marry.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+Add support for relative python imports

--- a/packages/sst/support/python-runtime/runtime.py
+++ b/packages/sst/support/python-runtime/runtime.py
@@ -91,7 +91,12 @@ if __name__ == '__main__':
         # would fail with error ModuleNotFoundError
         sys.path.append(args.src_path)
 
-        module = import_module(args.handler_module)
+        # remove leading zeros for relative imports
+        if args.handler_module.startswith('.'):
+          module = import_module(args.handler_module[1:])
+        else: 
+          module = import_module(args.handler_module)
+
         handler = getattr(module, args.handler_name)
         result = handler(event, context)
         data = json.dumps(result, default=handleUnserializable).encode("utf-8")


### PR DESCRIPTION
## Overview
Received an error related to relative imports when importing local Python modules in SST Python functions:
```log
Traceback (most recent call last):
  File "/path/to/file/repo_name/node_modules/sst/support/python-runtime/runtime.py", line 97, in <module>
    module = import_module(args.handler_module)
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/importlib/__init__.py", line 122, in import_module
    raise TypeError(msg.format(name))
TypeError: the 'package' argument is required to perform a relative import for '.testFunction'
```

Ref: https://discord.com/channels/983865673656705025/1083054101652328478


