### PR TITLE
fix: graphql examples front-end error

### DIFF
--- a/examples/create-sst-dynamo/packages/web/src/main.tsx
+++ b/examples/create-sst-dynamo/packages/web/src/main.tsx
@@ -1,13 +1,14 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import { Provider as UrqlProvider, createClient } from "urql";
+import { Provider as UrqlProvider, Client, cacheExchange, fetchExchange } from "urql";
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import Home from "./pages/Home";
 import Article from "./pages/Article";
 import "./globals.css";
 
-const urql = createClient({
+const urql = new Client({
   url: import.meta.env.VITE_GRAPHQL_URL,
+  exchanges: [cacheExchange, fetchExchange],
 });
 
 ReactDOM.createRoot(document.getElementById("root")!).render(

--- a/examples/create-sst-rds/packages/web/src/main.tsx
+++ b/examples/create-sst-rds/packages/web/src/main.tsx
@@ -1,13 +1,14 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import { Provider as UrqlProvider, createClient } from "urql";
+import { Provider as UrqlProvider, Client, cacheExchange, fetchExchange } from "urql";
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import Home from "./pages/Home";
 import Article from "./pages/Article";
 import "./globals.css";
 
-const urql = createClient({
+const urql = new Client({
   url: import.meta.env.VITE_GRAPHQL_URL,
+  exchanges: [cacheExchange, fetchExchange],
 });
 
 ReactDOM.createRoot(document.getElementById("root")!).render(

--- a/examples/graphql-dynamo/packages/web/src/main.tsx
+++ b/examples/graphql-dynamo/packages/web/src/main.tsx
@@ -1,13 +1,14 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import { Provider as UrqlProvider, createClient } from "urql";
+import { Provider as UrqlProvider, Client, cacheExchange, fetchExchange } from "urql";
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import Home from "./pages/Home";
 import Article from "./pages/Article";
 import "./globals.css";
 
-const urql = createClient({
+const urql = new Client({
   url: import.meta.env.VITE_GRAPHQL_URL,
+  exchanges: [cacheExchange, fetchExchange],
 });
 
 ReactDOM.createRoot(document.getElementById("root")!).render(

--- a/packages/create-sst/bin/presets/graphql/basic/templates/packages/web/src/main.tsx
+++ b/packages/create-sst/bin/presets/graphql/basic/templates/packages/web/src/main.tsx
@@ -1,13 +1,14 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import { Provider as UrqlProvider, createClient } from "urql";
+import { Provider as UrqlProvider, Client, cacheExchange, fetchExchange } from "urql";
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import Home from "./pages/Home";
 import Article from "./pages/Article";
 import "./globals.css";
 
-const urql = createClient({
+const urql = new Client({
   url: import.meta.env.VITE_GRAPHQL_URL,
+  exchanges: [cacheExchange, fetchExchange],
 });
 
 ReactDOM.createRoot(document.getElementById("root")!).render(


### PR DESCRIPTION
The `urql` library api has changed causing the graphql examples to error when running the front-end.

Instead of calling `createClient`, the `urql` client must now be invoked with `new Client`.  Additionally, new client params are required. The new syntax is:


```
import { Provider as UrqlProvider, Client, cacheExchange, fetchExchange } from "urql";
…
const urql = new Client({
  url: import.meta.env.VITE_GRAPHQL_URL,
  exchanges: [cacheExchange, fetchExchange],
});
```

This PR updates the examples with these changes.