### PR TITLE
Update deprecated Github actions

### DIFF
--- a/.github/workflows/aws-cdk.yml
+++ b/.github/workflows/aws-cdk.yml
@@ -13,7 +13,7 @@ jobs:
 
       - name: Setup Node.js
         # https://github.com/actions/setup-node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 16.x
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -12,7 +12,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - id: set-matrix
         run: echo "::set-output name=matrix::$(ls packages/create-sst/bin/presets/examples/ | jq -R -s -c 'split("\n")[:-1]')"
   generate:
@@ -22,7 +22,7 @@ jobs:
       matrix:
         example: ${{ fromJson(needs.list.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
@@ -67,7 +67,7 @@ jobs:
     needs: generate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,11 +15,11 @@ jobs:
     steps:
       - name: Checkout Repo
         # https://github.com/actions/checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Node.js
         # https://github.com/actions/setup-node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 16.x
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,11 +12,11 @@ jobs:
     steps:
       - name: Checkout Repo
         # https://github.com/actions/checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Node.js
         # https://github.com/actions/setup-node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 16.x
 


### PR DESCRIPTION
Removes Github actions deprecation warnings

Updated actions:
- actions/checkout
- actions/setup-node