### PR TITLE
Disable Introspection in GraphQL Helix

### DIFF
--- a/.changeset/breezy-comics-cross.md
+++ b/.changeset/breezy-comics-cross.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+Disable Introspection in GraphQL Helix

--- a/packages/sst/src/node/graphql/index.ts
+++ b/packages/sst/src/node/graphql/index.ts
@@ -55,7 +55,7 @@ export function GraphQLHandler<C>(config: GraphQLHandlerConfig<C>) {
     };
 
     const { operationName, query, variables } = getGraphQLParameters(request);
-    const validationRules = config.disableIntrospection ? [...specifiedRules, NoSchemaIntrospectionCustomRule] : [specifiedRules];
+    const validationRules = config.disableIntrospection ? [...specifiedRules, NoSchemaIntrospectionCustomRule] : [...specifiedRules];
 
     const result = await processRequest({
       operationName,

--- a/packages/sst/src/node/graphql/index.ts
+++ b/packages/sst/src/node/graphql/index.ts
@@ -1,6 +1,6 @@
 import { Context } from "aws-lambda";
 import { APIGatewayProxyEventV2 } from "aws-lambda";
-import { GraphQLSchema } from "graphql";
+import { GraphQLSchema, specifiedRules, NoSchemaIntrospectionCustomRule } from "graphql";
 import {
   ExecutionContext,
   FormatPayloadParams,
@@ -39,6 +39,10 @@ interface GraphQLHandlerConfig<C> {
    * Override the GraphQL execute function, sometimes used by plugins
    */
   execute?: ProcessRequestOptions<any, any>["execute"];
+  /**
+   * Disable introspection for production
+   */
+  disableIntrospection?: boolean;
 }
 
 export function GraphQLHandler<C>(config: GraphQLHandlerConfig<C>) {
@@ -51,12 +55,14 @@ export function GraphQLHandler<C>(config: GraphQLHandlerConfig<C>) {
     };
 
     const { operationName, query, variables } = getGraphQLParameters(request);
+    const validationRules = config.disableIntrospection ? [...specifiedRules, NoSchemaIntrospectionCustomRule] : [specifiedRules];
 
     const result = await processRequest({
       operationName,
       query,
       variables,
       request,
+      validationRules,
       execute: config.execute,
       schema: config.schema,
       formatPayload: config.formatPayload as any,


### PR DESCRIPTION
# Description
This pull request adds the ability to disable introspection in GraphQL Helix by using the disableIntrospection flag in the GraphQLHandlerConfig object. This feature allows for increased security in production environments by preventing unauthorized clients from querying the server's schema.

# Changes
The following changes have been made:

1. Import the necessary dependencies: specifiedRules and NoSchemaIntrospectionCustomRule from graphql
2. Add a new optional disableIntrospection boolean property to the GraphQLHandlerConfig interface
3. In the GraphQLHandler function, set the validationRules variable based on the value of disableIntrospection
4. Pass the validationRules variable to the processRequest function

# Reference
[Here](https://github.com/contra/graphql-helix/issues/50#issuecomment-922414985) is a conversation posted on graphql-helix 