### PR TITLE
ApiGatewayV1Api: do not bind imported API

### DIFF
--- a/.changeset/young-parents-poke.md
+++ b/.changeset/young-parents-poke.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+ApiGatewayV1Api: do not bind imported API

--- a/packages/sst/src/constructs/ApiGatewayV1Api.ts
+++ b/packages/sst/src/constructs/ApiGatewayV1Api.ts
@@ -781,7 +781,12 @@ export class ApiGatewayV1Api<
   }
 
   /** @internal */
-  public getFunctionBinding(): FunctionBindingProps {
+  public getFunctionBinding() {
+    // Do not bind imported ApiGatewayV1Api APIs b/c we don't know the API URL
+    if (!this.url) {
+      return;
+    }
+
     return {
       clientPackage: "api",
       variables: {
@@ -791,7 +796,7 @@ export class ApiGatewayV1Api<
         },
       },
       permissions: {},
-    };
+    } as FunctionBindingProps;
   }
 
   private createRestApi() {


### PR DESCRIPTION
Hi 👋 thank you for such an incredible open source library!

I've been trying to import an existing REST API but been facing a `Parameter_url/Resource [AWS::SSM::Parameter] is missing required property: value` error, which when searching the Discord help channel brought me to [this message](https://discord.com/channels/983865673656705025/1086385829708058644/1086385829708058644).

This PR copies the changes made in [this commit](https://github.com/serverless-stack/sst/commit/d3b50eed30790d30c4940f048099b6ae19cf8922) to ApiGatewayV1Api to prevent binding the `url` property when importing an existing API.

Thanks