### PR TITLE
fix: main.tsx to include exchange parameters

### DIFF
--- a/examples/graphql-rds/packages/web/src/main.tsx
+++ b/examples/graphql-rds/packages/web/src/main.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import { Provider as UrqlProvider, createClient } from "urql";
+import { Provider as UrqlProvider, createClient , cacheExchange, fetchExchange} from "urql";
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import Home from "./pages/Home";
 import Article from "./pages/Article";
@@ -8,7 +8,7 @@ import "./globals.css";
 
 const urql = createClient({
   url: import.meta.env.VITE_GRAPHQL_URL,
-  exchanges: []
+  exchanges: [ cacheExchange, fetchExchange ]
 });
 
 ReactDOM.createRoot(document.getElementById("root")!).render(

--- a/examples/graphql-rds/packages/web/src/main.tsx
+++ b/examples/graphql-rds/packages/web/src/main.tsx
@@ -8,6 +8,7 @@ import "./globals.css";
 
 const urql = createClient({
   url: import.meta.env.VITE_GRAPHQL_URL,
+  exchanges: []
 });
 
 ReactDOM.createRoot(document.getElementById("root")!).render(

--- a/examples/graphql-rds/packages/web/src/main.tsx
+++ b/examples/graphql-rds/packages/web/src/main.tsx
@@ -1,12 +1,12 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import { Provider as UrqlProvider, createClient , cacheExchange, fetchExchange} from "urql";
+import { Provider as UrqlProvider, Client , cacheExchange, fetchExchange} from "urql";
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import Home from "./pages/Home";
 import Article from "./pages/Article";
 import "./globals.css";
 
-const urql = createClient({
+const urql = new Client({
   url: import.meta.env.VITE_GRAPHQL_URL,
   exchanges: [ cacheExchange, fetchExchange ]
 });


### PR DESCRIPTION
Error: Argument of type '{ url: string; }' is not assignable to parameter of type 'ClientOptions'.
Property 'exchanges' is missing in type '{ url: string; }' but required in type 'ClientOptions'.ts(2345)
urql-core-chunk.d.ts(88, 5): 'exchanges' is declared here.

This error is being caused because when creating the urql client, it expects an object of type ClientOptions. However, you are passing in an object with only a url key, which doesn't match that expected type.