### PR TITLE
Fix a small typo in API Docs

### DIFF
--- a/packages/sst/src/constructs/StaticSite.ts
+++ b/packages/sst/src/constructs/StaticSite.ts
@@ -283,7 +283,7 @@ export interface StaticSiteProps {
      */
     id?: string;
     /**
-     * Allows you to override default settings this construct uses internally to ceate the bucket
+     * Allows you to override default settings this construct uses internally to create the bucket
      *
      * @example
      * ```js


### PR DESCRIPTION
Just a small typo I found while reading the API Docs!

Thank you for everything :pray: 