### PR TITLE
Doc: Update dead link to new location

### DIFF
--- a/packages/sst/src/constructs/RDS.ts
+++ b/packages/sst/src/constructs/RDS.ts
@@ -73,7 +73,7 @@ export interface RDSProps {
   };
 
   /**
-   * Path to the directory that contains the migration scripts. The `RDS` construct uses [Kysely](https://koskimas.github.io/kysely/) to run and manage schema migrations. The `migrations` prop should point to the folder where your migration files are.
+   * Path to the directory that contains the migration scripts. The `RDS` construct uses [Kysely](https://kysely-org.github.io/kysely/) to run and manage schema migrations. The `migrations` prop should point to the folder where your migration files are.
    *
    * @example
    *

--- a/www/docs/constructs/RDS.about.md
+++ b/www/docs/constructs/RDS.about.md
@@ -7,7 +7,7 @@ The `RDS` construct is a higher level CDK construct that makes it easy to create
 
 ## Migrations
 
-The `RDS` construct uses [Kysely](https://koskimas.github.io/kysely/) to run and manage schema migrations. The `migrations` prop should point to the folder where your migration files are.
+The `RDS` construct uses [Kysely](https://kysely-org.github.io/kysely/) to run and manage schema migrations. The `migrations` prop should point to the folder where your migration files are.
 
 ```js
 new RDS(stack, "Database", {

--- a/www/docs/constructs/v0/RDS.md
+++ b/www/docs/constructs/v0/RDS.md
@@ -80,7 +80,7 @@ new RDS(this, "Database", {
 });
 ```
 
-The `RDS` construct uses [Kysely](https://koskimas.github.io/kysely/) to run and manage schema migrations. The `migrations` prop should point to the folder where your migration files are.
+The `RDS` construct uses [Kysely](https://kysely-org.github.io/kysely/) to run and manage schema migrations. The `migrations` prop should point to the folder where your migration files are.
 
 On `sst deploy`, all migrations that have not yet been run will be run as a part of the deploy process. The migrations are executed in alphabetical order by their name.
 

--- a/www/docs/constructs/v1/RDS.about.md
+++ b/www/docs/constructs/v1/RDS.about.md
@@ -7,7 +7,7 @@
 
 ## Migrations
 
-The `RDS` construct uses [Kysely](https://koskimas.github.io/kysely/) to run and manage schema migrations. The `migrations` prop should point to the folder where your migration files are.
+The `RDS` construct uses [Kysely](https://kysely-org.github.io/kysely/) to run and manage schema migrations. The `migrations` prop should point to the folder where your migration files are.
 
 ```js
 new RDS(stack, "Database", {

--- a/www/docs/constructs/v1/RDS.tsdoc.md
+++ b/www/docs/constructs/v1/RDS.tsdoc.md
@@ -33,7 +33,7 @@ Database engine of the cluster. Cannot be changed once set.
 
 _Type_ : <span class="mono">string</span>
 
-Path to the directory that contains the migration scripts. The `RDS` construct uses [Kysely](https://koskimas.github.io/kysely/) to run and manage schema migrations. The `migrations` prop should point to the folder where your migration files are.
+Path to the directory that contains the migration scripts. The `RDS` construct uses [Kysely](https://kysely-org.github.io/kysely/) to run and manage schema migrations. The `migrations` prop should point to the folder where your migration files are.
 
 
 

--- a/www/docs/learn/initialize-the-database.md
+++ b/www/docs/learn/initialize-the-database.md
@@ -70,7 +70,7 @@ Recall from the [Project Structure](project-structure.md) chapter that the migra
 
 The starter creates the first migration for you. It's called `article` and you'll find it in `packages/core/migrations/1650000012557_article.mjs`.
 
-We use [Kysely](https://koskimas.github.io/kysely/) to build our SQL queries in a typesafe way. We use that for our migrations as well.
+We use [Kysely](https://kysely-org.github.io/kysely/) to build our SQL queries in a typesafe way. We use that for our migrations as well.
 
 ```js title="packages/core/migrations/1650000012557_article.mjs"
 import { Kysely } from "kysely";

--- a/www/docs/learn/write-to-the-database.md
+++ b/www/docs/learn/write-to-the-database.md
@@ -152,7 +152,7 @@ export function comments(articleID: string) {
 }
 ```
 
-We are using [Kysely](https://koskimas.github.io/kysely/) to run typesafe queries against our database.
+We are using [Kysely](https://kysely-org.github.io/kysely/) to run typesafe queries against our database.
 
 <details>
 <summary>Behind the scenes</summary>


### PR DESCRIPTION
Thanks for building this tool!

Very minor change, the github page for kysely looks like it has moved from https://koskimas.github.io/kysely/ to https://kysely-org.github.io/kysely/