### PR TITLE
doc: update missed kysely links

### DIFF
--- a/www/docs/constructs/RDS.about.md
+++ b/www/docs/constructs/RDS.about.md
@@ -39,7 +39,7 @@ async function down(db) {
 module.exports = { up, down };
 ```
 
-[Read more about writing migrations](https://kysely-org.github.io/kysely/#migrations/#migrations) over on the Kysely docs.
+[Read more about writing migrations](https://kysely-org.github.io/kysely/#migrations) over on the Kysely docs.
 
 ### Migrations with PostgreSQL
 

--- a/www/docs/constructs/RDS.about.md
+++ b/www/docs/constructs/RDS.about.md
@@ -39,7 +39,7 @@ async function down(db) {
 module.exports = { up, down };
 ```
 
-[Read more about writing migrations](https://koskimas.github.io/kysely/#migrations) over on the Kysely docs.
+[Read more about writing migrations](https://kysely-org.github.io/kysely/#migrations/#migrations) over on the Kysely docs.
 
 ### Migrations with PostgreSQL
 

--- a/www/docs/constructs/v0/RDS.md
+++ b/www/docs/constructs/v0/RDS.md
@@ -146,7 +146,7 @@ async function down(db) {
 module.exports = { up, down };
 ```
 
-[Read more about writing migrations](https://koskimas.github.io/kysely/#migrations) over on the Kysely docs.
+[Read more about writing migrations](https://kysely-org.github.io/kysely/#migrations) over on the Kysely docs.
 
 ### Configuring the RDS cluster
 

--- a/www/docs/constructs/v1/RDS.about.md
+++ b/www/docs/constructs/v1/RDS.about.md
@@ -1,7 +1,7 @@
  The `RDS` construct is a higher level CDK construct that makes it easy to create an [RDS Serverless Cluster](https://aws.amazon.com/rds/). It uses the following defaults:
  
    - Defaults to using the [Serverless v1 On-Demand autoscaling configuration](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless.html) to make it serverless.
-   - Provides a built-in interface for running schema migrations using [Kysely](https://koskimas.github.io/kysely/#migrations).
+   - Provides a built-in interface for running schema migrations using [Kysely](https://kysely-org.github.io/kysely/#migrations).
    - Enables [Data API](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/data-api.html) to allow your Lambda functions to access the database cluster without needing to deploy the functions in a VPC (virtual private cloud).
    - Enables [Backup Snapshot](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/BackupRestoreAurora.html) to make sure that you don't lose your data.
 

--- a/www/docs/learn/index.md
+++ b/www/docs/learn/index.md
@@ -74,7 +74,7 @@ We also use a couple of other notable open-source libraries in our setup.
 
 ### Other libraries
 
-- [Kysely](https://koskimas.github.io/kysely), a typesafe TypeScript SQL query builder
+- [Kysely](https://kysely-org.github.io/kysely/), a typesafe TypeScript SQL query builder
 - [Pothos](https://pothos-graphql.dev), a typesafe TypeScript GraphQL schema builder
 - [Urql](https://formidable.com/open-source/urql/) with [Genql](https://genql.vercel.app), a typesafe GraphQL client
 


### PR DESCRIPTION
Minor changes to the doc regarding Kysely links. This is an extension of this merged PR https://github.com/serverless-stack/sst/pull/2788

Some were missed while going through the docs.