### PR TITLE
Auth: fix missing close quote in documentation snippet

### DIFF
--- a/www/docs/clients/auth.md
+++ b/www/docs/clients/auth.md
@@ -119,7 +119,7 @@ import { useSession } from "sst/node/auth";
 
 const session = useSession();
 
-if (session.type === "user) {
+if (session.type === "user") {
   console.log(session.properties.userID);
 }
 ```


### PR DESCRIPTION
Code snippet on auth docs page ([https://docs.sst.dev/clients/auth#usesession](https://docs.sst.dev/clients/auth#usesession)) was missing a closing quotation mark in syntax. This fixes that.