### PR TITLE
[construct/deprecated]: Import correctly support/edge-function for deprected NextJsSite

### DIFF
--- a/.changeset/popular-kids-lick.md
+++ b/.changeset/popular-kids-lick.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+deprecated/NextjsSite: fix custom resource import path

--- a/packages/sst/src/constructs/deprecated/cross-region-helper.ts
+++ b/packages/sst/src/constructs/deprecated/cross-region-helper.ts
@@ -64,7 +64,7 @@ export function createFunction(
   if (!provider) {
     provider = new lambda.Function(stack, providerId, {
       code: lambda.Code.fromAsset(
-        path.join(__dirname, "../../../support/edge-function")
+        path.join(__dirname, "../../support/edge-function")
       ),
       handler: "edge-lambda.handler",
       runtime: lambda.Runtime.NODEJS_16_X,
@@ -112,7 +112,7 @@ export function createVersion(
   if (!provider) {
     provider = new lambda.Function(stack, providerId, {
       code: lambda.Code.fromAsset(
-        path.join(__dirname, "../../../support/edge-function")
+        path.join(__dirname, "../../support/edge-function")
       ),
       handler: "edge-lambda-version.handler",
       runtime: lambda.Runtime.NODEJS_16_X,

--- a/packages/sst/src/constructs/deprecated/cross-region-helper.ts
+++ b/packages/sst/src/constructs/deprecated/cross-region-helper.ts
@@ -20,7 +20,7 @@ export function getOrCreateBucket(scope: Construct): cdk.CustomResource {
   // Create provider
   const provider = new lambda.Function(stack, providerId, {
     code: lambda.Code.fromAsset(
-      path.join(__dirname, "../../../support/edge-function")
+      path.join(__dirname, "../../support/edge-function")
     ),
     handler: "s3-bucket.handler",
     runtime: lambda.Runtime.NODEJS_16_X,


### PR DESCRIPTION
Fixes the [issue raised on Discord channel](https://discord.com/channels/983865673656705025/1088244131429617714/1098996498810814547) when using deprecated `NextjsSite`:

```
Error occured making stack!
Error: Cannot find asset at home/mono/node_modules/support/edge-function
Trace: Error: Cannot find asset at home/mono/node_modules/support/edge-function
    at new AssetStaging (home/mono/node_modules/aws-cdk-lib/core/lib/asset-staging.js:1:1402)
    at new Asset (home/mono/node_modules/aws-cdk-lib/aws-s3-assets/lib/asset.js:1:736)
    at AssetCode.bind (home/mono/node_modules/aws-cdk-lib/aws-lambda/lib/code.js:1:4628)
    at new Function (home/mono/node_modules/aws-cdk-lib/aws-lambda/lib/function.js:1:7479)
    at Module.getOrCreateBucket (file://home/mono/node_modules/sst/constructs/deprecated/cross-region-helper.js:18:22)
    at NextjsSite.createEdgeFunctionInNonUE1 (file://home/mono/node_modules/sst/constructs/deprecated/NextjsSite.js:362:44)
    at NextjsSite.createEdgeFunction (file://home/mono/node_modules/sst/constructs/deprecated/NextjsSite.js:320:20)
    at new NextjsSite (file://home/mono/node_modules/sst/constructs/deprecated/NextjsSite.js:150:41)
    at ClientStack (home/mono/apps/zero-client/lib/client.stack.ts:23:19)
    at <anonymous> (home/mono/libs/stacks/src/common/stacks.ts:21:14)
    at process.<anonymous> (file://home/mono/node_modules/sst/cli/sst.js:56:17)
    at process.emit (node:events:525:35)
    at process.emit (node:domain:489:12)
    at process._fatalException (node:internal/process/execution:149:25)
    at processPromiseRejections (node:internal/process/promises:279:13)
    at processTicksAndRejections (node:internal/process/task_queues:97:32)
```

We are in `sst/src/constructs/deprecated` importing `../../../support/edge-function`, which actually tries to get the file located in `sst/support/edge-function`. However, the correct file is located in `sst/src/support/edge-function`, we're going back too far.