### PR TITLE
Fix link in eventbus example README.md

### DIFF
--- a/examples/eventbus/README.md
+++ b/examples/eventbus/README.md
@@ -4,7 +4,7 @@ An example serverless app created with SST.
 
 ## Getting Started
 
-[**Read the tutorial**](https://sst.dev/examples/how-to-use-eventbus-in-your-serverless-app.html)
+[**Read the tutorial**](https://sst.dev/examples/how-to-use-event-bus-in-your-serverless-app.html)
 
 Install the example.
 


### PR DESCRIPTION
I was going through some of the examples and noticed this broken link. Im excited about trying to integrate sst into some of the serverless applications that badly need updates at my company after seeing @thdxr speak at react conf miami! 

Side note: Im would love to see more possibilities with EventBridge similar to [this video](https://www.youtube.com/watch?v=iMsPztMiFIk). Any additional resources would be appreciated!