### PR TITLE
Cognito: Expose cfnIdentityPoolRoleAttachment

### DIFF
--- a/.changeset/twenty-monkeys-drive.md
+++ b/.changeset/twenty-monkeys-drive.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+Cognito: expose cfnIdentityPoolRoleAttachment prop

--- a/packages/sst/src/constructs/Cognito.ts
+++ b/packages/sst/src/constructs/Cognito.ts
@@ -197,6 +197,7 @@ export class Cognito extends Construct implements SSTConstruct {
     userPool: IUserPool;
     userPoolClient: IUserPoolClient;
     cfnIdentityPool?: CfnIdentityPool;
+    cfnIdentityPoolRoleAttachment?: CfnIdentityPoolRoleAttachment;
     authRole: Role;
     unauthRole: Role;
   };
@@ -556,13 +557,17 @@ export class Cognito extends Construct implements SSTConstruct {
     this.cdk.unauthRole = this.createUnauthRole(this.cdk.cfnIdentityPool);
 
     // Attach roles to Identity Pool
-    new CfnIdentityPoolRoleAttachment(this, "IdentityPoolRoleAttachment", {
-      identityPoolId: this.cdk.cfnIdentityPool.ref,
-      roles: {
-        authenticated: this.cdk.authRole.roleArn,
-        unauthenticated: this.cdk.unauthRole.roleArn,
-      },
-    });
+    this.cdk.cfnIdentityPoolRoleAttachment = new CfnIdentityPoolRoleAttachment(
+      this,
+      "IdentityPoolRoleAttachment",
+      {
+        identityPoolId: this.cdk.cfnIdentityPool.ref,
+        roles: {
+          authenticated: this.cdk.authRole.roleArn,
+          unauthenticated: this.cdk.unauthRole.roleArn,
+        },
+      }
+    );
   }
 
   private addTriggers(): void {

--- a/www/generate.mjs
+++ b/www/generate.mjs
@@ -48,6 +48,7 @@ const CDK_DOCS_MAP = {
   SignInAliases: "aws_cognito",
   UserPoolProps: "aws_cognito",
   CfnIdentityPool: "aws_cognito",
+  CfnIdentityPoolRoleAttachment: "aws_cognito",
   IUserPoolClient: "aws_cognito",
   UserPoolClientOptions: "aws_cognito",
   Bucket: "aws_s3",


### PR DESCRIPTION
Exposing this allows users to work with the role configuration using override: 

```js
cognito.cdk.CfnIdentityPoolRoleAttachment.addOverride("Properties.RoleMappings", {...})
```
 
One basic use case is users from the pool to assume a role based on the group they belong. E.g `Type: "Token"`
