### PR TITLE
Fix repository link in packages.json

### DIFF
--- a/packages/sst/package.json
+++ b/packages/sst/package.json
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/estyrke/serverless-stack.git",
+    "url": "git+https://github.com/serverless-stack/sst.git",
     "directory": "packages/cli"
   },
   "exports": {


### PR DESCRIPTION
SST package no longer points to the official repo. Introduced in #2792