### PR TITLE
feat: WebSocketApiHandler

### DIFF
--- a/.changeset/cold-dingos-drive.md
+++ b/.changeset/cold-dingos-drive.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+Updated the function binding to include httpsUrl as that is required to send messages using the ApiGateway client

--- a/.changeset/fifty-ants-whisper.md
+++ b/.changeset/fifty-ants-whisper.md
@@ -2,4 +2,4 @@
 "sst": patch
 ---
 
-Added WebsocketApiHandler so that we can use the auth sessions inside of a Websocket's connect and disconnect requests
+Added WebSocketApiHandler so that we can use the auth sessions inside of a WebSocket's connect and disconnect requests

--- a/.changeset/fifty-ants-whisper.md
+++ b/.changeset/fifty-ants-whisper.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+Added WebsocketApiHandler so that we can use the auth sessions inside of a Websocket's connect and disconnect requests

--- a/.changeset/gentle-mails-compare.md
+++ b/.changeset/gentle-mails-compare.md
@@ -1,0 +1,6 @@
+---
+"sst": patch
+"@serverless-stack/docs": patch
+---
+
+Added a new WebSocketApiHandler to allow for websockets to use session hooks

--- a/packages/sst/src/constructs/WebSocketApi.ts
+++ b/packages/sst/src/constructs/WebSocketApi.ts
@@ -34,7 +34,7 @@ export interface WebSocketApiAccessLogProps
 
 export interface WebSocketApiProps {
   /**
-   * The routes for the Websocket API
+   * The routes for the WebSocket API
    *
    * @example
    * ```js

--- a/packages/sst/src/constructs/WebSocketApi.ts
+++ b/packages/sst/src/constructs/WebSocketApi.ts
@@ -470,11 +470,18 @@ export class WebSocketApi extends Construct implements SSTConstruct {
   /** @internal */
   public getFunctionBinding(): FunctionBindingProps {
     return {
-      clientPackage: "api",
+      clientPackage: "websocket-api",
       variables: {
         url: {
           type: "plain",
           value: this.customDomainUrl || this.url,
+        },
+        httpsUrl: {
+          type: "plain",
+          value: (this.customDomainUrl || this.url).replace(
+            "wss://",
+            "https://"
+          ),
         },
       },
       permissions: {

--- a/packages/sst/src/context/handler.ts
+++ b/packages/sst/src/context/handler.ts
@@ -1,6 +1,12 @@
 import {
+  APIGatewayProxyEventHeaders,
+  APIGatewayProxyEventMultiValueHeaders,
+  APIGatewayProxyEventMultiValueQueryStringParameters,
+  APIGatewayProxyEventQueryStringParameters,
   APIGatewayProxyEventV2,
+  APIGatewayProxyResultV2,
   APIGatewayProxyStructuredResultV2,
+  APIGatewayProxyWebsocketEventV2,
   Context as LambdaContext,
   SQSBatchResponse,
   SQSEvent,
@@ -12,13 +18,24 @@ export interface Handlers {
     event: APIGatewayProxyEventV2;
     response: APIGatewayProxyStructuredResultV2 | void;
   };
+  ws: {
+    // These fields are being returned when we print it but for some reason not
+    // part of the APIGatewayProxyWebsocketEventV2 type
+    event: APIGatewayProxyWebsocketEventV2 & {
+      headers?: APIGatewayProxyEventHeaders;
+      multiValueHeaders?: APIGatewayProxyEventMultiValueHeaders;
+      queryStringParameters?: APIGatewayProxyEventQueryStringParameters | null;
+      multiValueQueryStringParameters?: APIGatewayProxyEventMultiValueQueryStringParameters | null;
+    };
+    response: APIGatewayProxyResultV2;
+  };
   sqs: {
     event: SQSEvent;
     response: SQSBatchResponse;
   };
 }
 
-type HandlerTypes = keyof Handlers;
+export type HandlerTypes = keyof Handlers;
 
 type Requests = {
   [key in HandlerTypes]: {
@@ -29,6 +46,11 @@ type Requests = {
 }[HandlerTypes];
 
 const RequestContext = Context.create<Requests>("RequestContext");
+
+export function useContextType(): HandlerTypes {
+  const ctx = RequestContext.use();
+  return ctx.type;
+}
 
 export function useEvent<Type extends HandlerTypes>(type: Type) {
   const ctx = RequestContext.use();

--- a/packages/sst/src/node/api/index.ts
+++ b/packages/sst/src/node/api/index.ts
@@ -1,6 +1,11 @@
 import { createProxy } from "../util/index.js";
 import { Context } from "../../context/context.js";
-import { useEvent, Handler, HandlerTypes } from "../../context/handler.js";
+import {
+  useEvent,
+  Handler,
+  HandlerTypes,
+  useContextType,
+} from "../../context/handler.js";
 import { APIGatewayProxyStructuredResultV2 } from "aws-lambda";
 
 export interface ApiResources {}
@@ -45,16 +50,15 @@ export function useCookie(name: string) {
   return cookies[name] as string | undefined;
 }
 
-export const useBody = /* @__PURE__ */ Context.memo(
-  (type: ApiHandlerTypes = "api") => {
-    const evt = useEvent(type);
-    if (!evt.body) return;
-    const body = evt.isBase64Encoded
-      ? Buffer.from(evt.body, "base64").toString()
-      : evt.body;
-    return body;
-  }
-);
+export const useBody = /* @__PURE__ */ Context.memo(() => {
+  const type = useContextType() as ApiHandlerTypes;
+  const evt = useEvent(type);
+  if (!evt.body) return;
+  const body = evt.isBase64Encoded
+    ? Buffer.from(evt.body, "base64").toString()
+    : evt.body;
+  return body;
+});
 
 export const useJsonBody = /* @__PURE__ */ Context.memo(() => {
   const body = useBody();
@@ -144,7 +148,8 @@ export const useResponse = /* @__PURE__ */ Context.memo(() => {
   return result;
 });
 
-export function useDomainName(type: ApiHandlerTypes = "api") {
+export function useDomainName() {
+  const type = useContextType() as ApiHandlerTypes;
   const evt = useEvent(type);
   return evt.requestContext.domainName;
 }
@@ -154,13 +159,14 @@ export function useMethod() {
   return evt.requestContext.http.method;
 }
 
-export function useHeaders(type: ApiHandlerTypes = "api") {
+export function useHeaders() {
+  const type = useContextType() as ApiHandlerTypes;
   const evt = useEvent(type);
   return evt.headers || {};
 }
 
-export function useHeader(key: string, type: ApiHandlerTypes = "api") {
-  const headers = useHeaders(type);
+export function useHeader(key: string) {
+  const headers = useHeaders();
   return headers[key];
 }
 
@@ -169,17 +175,15 @@ export function useFormValue(name: string) {
   return params?.get(name);
 }
 
-export function useQueryParams(type: ApiHandlerTypes = "api") {
+export function useQueryParams() {
+  const type = useContextType() as ApiHandlerTypes;
   const evt = useEvent(type);
   const query = evt.queryStringParameters || {};
   return query;
 }
 
-export function useQueryParam<T = string>(
-  name: string,
-  type: ApiHandlerTypes = "api"
-) {
-  return useQueryParams(type)[name] as T | undefined;
+export function useQueryParam<T = string>(name: string) {
+  return useQueryParams()[name] as T | undefined;
 }
 
 export function usePathParams() {

--- a/packages/sst/src/node/api/index.ts
+++ b/packages/sst/src/node/api/index.ts
@@ -6,15 +6,12 @@ import { APIGatewayProxyStructuredResultV2 } from "aws-lambda";
 export interface ApiResources {}
 export interface AppSyncApiResources {}
 export interface ApiGatewayV1ApiResources {}
-export interface WebSocketApiResources {}
 
 export const Api = /* @__PURE__ */ createProxy<ApiResources>("Api");
 export const AppSyncApi =
   /* @__PURE__ */ createProxy<AppSyncApiResources>("AppSyncApi");
 export const ApiGatewayV1Api =
   /* @__PURE__ */ createProxy<ApiGatewayV1ApiResources>("ApiGatewayV1Api");
-export const WebSocketApi =
-  /* @__PURE__ */ createProxy<WebSocketApiResources>("WebSocketApi");
 
 /**
  * Create a new api handler that can be used to create an authenticated session.

--- a/packages/sst/src/node/auth/session.ts
+++ b/packages/sst/src/node/auth/session.ts
@@ -1,7 +1,7 @@
 import { createSigner, createVerifier, SignerOptions } from "fast-jwt";
 import { APIGatewayProxyStructuredResultV2 } from "aws-lambda";
 import { Context } from "../../context/context.js";
-import { ApiHandlerTypes, useCookie, useHeader } from "../api/index.js";
+import { useCookie, useHeader } from "../api/index.js";
 import { getPrivateKey, getPublicKey } from "./auth.js";
 import { useContextType } from "../../context/handler.js";
 
@@ -18,12 +18,12 @@ export type SessionValue = {
 
 const SessionMemo = /* @__PURE__ */ Context.memo(() => {
   // Get the context type and hooks that match that type
-  const ctxType = useContextType();
   let token = "";
 
-  const header = useHeader("authorization", ctxType as ApiHandlerTypes)!;
+  const header = useHeader("authorization")!;
   if (header) token = header.substring(7);
 
+  const ctxType = useContextType();
   const cookie = ctxType === "api" ? useCookie("auth-token") : undefined;
   if (cookie) token = cookie;
 

--- a/packages/sst/src/node/auth/session.ts
+++ b/packages/sst/src/node/auth/session.ts
@@ -27,6 +27,16 @@ const SessionMemo = /* @__PURE__ */ Context.memo(() => {
   const cookie = ctxType === "api" ? useCookie("auth-token") : undefined;
   if (cookie) token = cookie;
 
+  // WebSocket may also set the token in the protocol header
+  // TODO: Once https://github.com/serverless-stack/sst/pull/2838 is merged,
+  // then we should no longer need to check both casing for the header.
+  const wsProtocol =
+    ctxType === "ws"
+      ? useHeader("sec-websocket-protocol") ||
+        useHeader("Sec-WebSocket-Protocol")
+      : undefined;
+  if (wsProtocol) token = wsProtocol.split(",")[0].trim();
+
   if (token) {
     const jwt = createVerifier({
       algorithms: ["RS512"],

--- a/packages/sst/src/node/auth/session.ts
+++ b/packages/sst/src/node/auth/session.ts
@@ -20,22 +20,30 @@ export type SessionValue = {
   };
 }[keyof SessionTypes];
 
-const hooksForContextTypes: Record<
-  Extract<HandlerTypes, "api" | "ws">,
-  {
-    useHeader: (name: string) => string;
-    useCookie: (name: string) => string;
-  }
-> = {
+type Hooks = {
+  useHeader: (name: string) => string | undefined;
+  useCookie: (name: string) => string | undefined;
+};
+
+const hooksForContextTypes: Record<HandlerTypes, Hooks | undefined> = {
   api: { useHeader: useApiHeader, useCookie: useApiCookie },
-  ws: { useHeader: useWebsocketHeader, useCookie: () => "" },
+  ws: { useHeader: useWebsocketHeader, useCookie: () => undefined },
+  sqs: undefined,
 };
 
 const SessionMemo = /* @__PURE__ */ Context.memo(() => {
   // Get the context type and hooks that match that type
   const ctxType = useContextType();
   const hooks = hooksForContextTypes[ctxType];
-  if (!hooks) throw new Error(`Invalid context type: ${ctxType} for auth`);
+  if (!hooks) {
+    console.warn(
+      `Invalid context type: ${ctxType} for auth, returning public session`
+    );
+    return {
+      type: "public",
+      properties: {},
+    };
+  }
   let token = "";
 
   const header = hooks.useHeader("authorization")!;

--- a/packages/sst/src/node/auth/session.ts
+++ b/packages/sst/src/node/auth/session.ts
@@ -1,13 +1,9 @@
 import { createSigner, createVerifier, SignerOptions } from "fast-jwt";
 import { APIGatewayProxyStructuredResultV2 } from "aws-lambda";
 import { Context } from "../../context/context.js";
-import {
-  useCookie as useApiCookie,
-  useHeader as useApiHeader,
-} from "../api/index.js";
-import { useHeader as useWebSocketHeader } from "../websocket-api/index.js";
+import { ApiHandlerTypes, useCookie, useHeader } from "../api/index.js";
 import { getPrivateKey, getPublicKey } from "./auth.js";
-import { HandlerTypes, useContextType } from "../../context/handler.js";
+import { useContextType } from "../../context/handler.js";
 
 export interface SessionTypes {
   public: {};
@@ -20,36 +16,15 @@ export type SessionValue = {
   };
 }[keyof SessionTypes];
 
-type Hooks = {
-  useHeader: (name: string) => string | undefined;
-  useCookie: (name: string) => string | undefined;
-};
-
-const hooksForContextTypes: Record<HandlerTypes, Hooks | undefined> = {
-  api: { useHeader: useApiHeader, useCookie: useApiCookie },
-  ws: { useHeader: useWebSocketHeader, useCookie: () => undefined },
-  sqs: undefined,
-};
-
 const SessionMemo = /* @__PURE__ */ Context.memo(() => {
   // Get the context type and hooks that match that type
   const ctxType = useContextType();
-  const hooks = hooksForContextTypes[ctxType];
-  if (!hooks) {
-    console.warn(
-      `Invalid context type: ${ctxType} for auth, returning public session`
-    );
-    return {
-      type: "public",
-      properties: {},
-    };
-  }
   let token = "";
 
-  const header = hooks.useHeader("authorization")!;
+  const header = useHeader("authorization", ctxType as ApiHandlerTypes)!;
   if (header) token = header.substring(7);
 
-  const cookie = hooks.useCookie("auth-token");
+  const cookie = ctxType === "api" ? useCookie("auth-token") : undefined;
   if (cookie) token = cookie;
 
   if (token) {

--- a/packages/sst/src/node/auth/session.ts
+++ b/packages/sst/src/node/auth/session.ts
@@ -5,7 +5,7 @@ import {
   useCookie as useApiCookie,
   useHeader as useApiHeader,
 } from "../api/index.js";
-import { useHeader as useWebsocketHeader } from "../websocket-api/index.js";
+import { useHeader as useWebSocketHeader } from "../websocket-api/index.js";
 import { getPrivateKey, getPublicKey } from "./auth.js";
 import { HandlerTypes, useContextType } from "../../context/handler.js";
 
@@ -27,7 +27,7 @@ type Hooks = {
 
 const hooksForContextTypes: Record<HandlerTypes, Hooks | undefined> = {
   api: { useHeader: useApiHeader, useCookie: useApiCookie },
-  ws: { useHeader: useWebsocketHeader, useCookie: () => undefined },
+  ws: { useHeader: useWebSocketHeader, useCookie: () => undefined },
   sqs: undefined,
 };
 

--- a/packages/sst/src/node/future/auth/session.ts
+++ b/packages/sst/src/node/future/auth/session.ts
@@ -4,7 +4,7 @@ import {
   useCookie as useApiCookie,
   useHeader as useApiHeader,
 } from "../../api/index.js";
-import { useHeader as useWebsocketHeader } from "../../websocket-api/index.js";
+import { useHeader as useWebSocketHeader } from "../../websocket-api/index.js";
 import { Auth } from "../../auth/index.js";
 import { Config } from "../../config/index.js";
 import { HandlerTypes, useContextType } from "../../../context/handler.js";
@@ -27,7 +27,7 @@ type Hooks = {
 
 const hooksForContextTypes: Record<HandlerTypes, Hooks | undefined> = {
   api: { useHeader: useApiHeader, useCookie: useApiCookie },
-  ws: { useHeader: useWebsocketHeader, useCookie: () => undefined },
+  ws: { useHeader: useWebSocketHeader, useCookie: () => undefined },
   sqs: undefined,
 };
 

--- a/packages/sst/src/node/future/auth/session.ts
+++ b/packages/sst/src/node/future/auth/session.ts
@@ -1,6 +1,6 @@
 import { createSigner, createVerifier, SignerOptions } from "fast-jwt";
 import { Context } from "../../../context/context.js";
-import { ApiHandlerTypes, useCookie, useHeader } from "../../api/index.js";
+import { useCookie, useHeader } from "../../api/index.js";
 import { Auth } from "../../auth/index.js";
 import { Config } from "../../config/index.js";
 import { useContextType } from "../../../context/handler.js";
@@ -18,12 +18,12 @@ export type SessionValue = {
 
 const SessionMemo = /* @__PURE__ */ Context.memo(() => {
   // Get the context type and hooks that match that type
-  const ctxType = useContextType();
   let token = "";
 
-  const header = useHeader("authorization", ctxType as ApiHandlerTypes)!;
+  const header = useHeader("authorization")!;
   if (header) token = header.substring(7);
 
+  const ctxType = useContextType();
   const cookie = ctxType === "api" ? useCookie("sst_auth_token") : undefined;
   if (cookie) token = cookie;
 

--- a/packages/sst/src/node/future/auth/session.ts
+++ b/packages/sst/src/node/future/auth/session.ts
@@ -27,6 +27,16 @@ const SessionMemo = /* @__PURE__ */ Context.memo(() => {
   const cookie = ctxType === "api" ? useCookie("sst_auth_token") : undefined;
   if (cookie) token = cookie;
 
+  // WebSocket may also set the token in the protocol header
+  // TODO: Once https://github.com/serverless-stack/sst/pull/2838 is merged,
+  // then we should no longer need to check both casing for the header.
+  const wsProtocol =
+    ctxType === "ws"
+      ? useHeader("sec-websocket-protocol") ||
+        useHeader("Sec-WebSocket-Protocol")
+      : undefined;
+  if (wsProtocol) token = wsProtocol.split(",")[0].trim();
+
   if (token) {
     return Session.verify(token);
   }

--- a/packages/sst/src/node/future/auth/session.ts
+++ b/packages/sst/src/node/future/auth/session.ts
@@ -1,8 +1,13 @@
 import { createSigner, createVerifier, SignerOptions } from "fast-jwt";
 import { Context } from "../../../context/context.js";
-import { useCookie, useHeader } from "../../api/index.js";
+import {
+  useCookie as useApiCookie,
+  useHeader as useApiHeader,
+} from "../../api/index.js";
+import { useHeader as useWebsocketHeader } from "../../websocket-api/index.js";
 import { Auth } from "../../auth/index.js";
 import { Config } from "../../config/index.js";
+import { HandlerTypes, useContextType } from "../../../context/handler.js";
 
 export interface SessionTypes {
   public: {};
@@ -15,13 +20,29 @@ export type SessionValue = {
   };
 }[keyof SessionTypes];
 
+const hooksForContextTypes: Record<
+  Extract<HandlerTypes, "api" | "ws">,
+  {
+    useHeader: (name: string) => string;
+    useCookie: (name: string) => string;
+  }
+> = {
+  api: { useHeader: useApiHeader, useCookie: useApiCookie },
+  ws: { useHeader: useWebsocketHeader, useCookie: () => "" },
+};
+
 const SessionMemo = /* @__PURE__ */ Context.memo(() => {
+  // Get the context type and hooks that match that type
+  const ctxType = useContextType();
+  const hooks = hooksForContextTypes[ctxType];
+  if (!hooks) throw new Error(`Invalid context type: ${ctxType} for auth`);
+
   let token = "";
 
-  const header = useHeader("authorization")!;
+  const header = hooks.useHeader("authorization")!;
   if (header) token = header.substring(7);
 
-  const cookie = useCookie("sst_auth_token");
+  const cookie = hooks.useCookie("sst_auth_token");
   if (cookie) token = cookie;
 
   if (token) {

--- a/packages/sst/src/node/websocket-api/index.ts
+++ b/packages/sst/src/node/websocket-api/index.ts
@@ -1,0 +1,80 @@
+import { Context } from "../../context/context.js";
+import { Handler, useEvent } from "../../context/handler.js";
+import { createProxy } from "../util/index.js";
+
+export interface WebSocketApiResources {}
+
+export const WebSocketApi =
+  /* @__PURE__ */ createProxy<WebSocketApiResources>("WebSocketApi");
+
+/**
+ * Create a new WebsocketApi handler that can be used to create an
+ * authenticated session.
+ *
+ * @example
+ * ```ts
+ * export const handler = WebsocketApiHandler({
+ * })
+ * ```
+ */
+export function WebsocketApiHandler(cb: Parameters<typeof Handler<"ws">>[1]) {
+  return Handler("ws", async (evt, ctx) => {
+    const result = await cb(evt, ctx);
+    return result;
+  });
+}
+
+export const useBody = /* @__PURE__ */ Context.memo(() => {
+  const evt = useEvent("ws");
+  if (!evt.body) return;
+  const body = evt.isBase64Encoded
+    ? Buffer.from(evt.body, "base64").toString()
+    : evt.body;
+  return body;
+});
+
+export const useJsonBody = /* @__PURE__ */ Context.memo(() => {
+  const body = useBody();
+  if (!body) return;
+  return JSON.parse(body);
+});
+
+export function useRequestContext() {
+  const evt = useEvent("ws");
+  return evt.requestContext;
+}
+
+export function useDomainName() {
+  const requestContext = useRequestContext();
+  return requestContext.domainName;
+}
+
+export function useConnectionId() {
+  const requestContext = useRequestContext();
+  return requestContext.connectionId;
+}
+
+export function useEventType() {
+  const requestContext = useRequestContext();
+  return requestContext.eventType;
+}
+
+export function useHeaders() {
+  const evt = useEvent("ws");
+  return evt.headers || {};
+}
+
+export function useHeader(key: string) {
+  const headers = useHeaders();
+  return headers[key];
+}
+
+export function useQueryParams() {
+  const evt = useEvent("ws");
+  const query = evt.queryStringParameters || {};
+  return query;
+}
+
+export function useQueryParam<T = string>(name: string) {
+  return useQueryParams()[name] as T | undefined;
+}

--- a/packages/sst/src/node/websocket-api/index.ts
+++ b/packages/sst/src/node/websocket-api/index.ts
@@ -1,4 +1,3 @@
-import { Context } from "../../context/context.js";
 import { Handler, useEvent } from "../../context/handler.js";
 import { createProxy } from "../util/index.js";
 
@@ -24,29 +23,9 @@ export function WebSocketApiHandler(cb: Parameters<typeof Handler<"ws">>[1]) {
   });
 }
 
-export const useBody = /* @__PURE__ */ Context.memo(() => {
-  const evt = useEvent("ws");
-  if (!evt.body) return;
-  const body = evt.isBase64Encoded
-    ? Buffer.from(evt.body, "base64").toString()
-    : evt.body;
-  return body;
-});
-
-export const useJsonBody = /* @__PURE__ */ Context.memo(() => {
-  const body = useBody();
-  if (!body) return;
-  return JSON.parse(body);
-});
-
 export function useRequestContext() {
   const evt = useEvent("ws");
   return evt.requestContext;
-}
-
-export function useDomainName() {
-  const requestContext = useRequestContext();
-  return requestContext.domainName;
 }
 
 export function useConnectionId() {
@@ -57,24 +36,4 @@ export function useConnectionId() {
 export function useEventType() {
   const requestContext = useRequestContext();
   return requestContext.eventType;
-}
-
-export function useHeaders() {
-  const evt = useEvent("ws");
-  return evt.headers || {};
-}
-
-export function useHeader(key: string) {
-  const headers = useHeaders();
-  return headers[key];
-}
-
-export function useQueryParams() {
-  const evt = useEvent("ws");
-  const query = evt.queryStringParameters || {};
-  return query;
-}
-
-export function useQueryParam<T = string>(name: string) {
-  return useQueryParams()[name] as T | undefined;
 }

--- a/packages/sst/src/node/websocket-api/index.ts
+++ b/packages/sst/src/node/websocket-api/index.ts
@@ -8,16 +8,16 @@ export const WebSocketApi =
   /* @__PURE__ */ createProxy<WebSocketApiResources>("WebSocketApi");
 
 /**
- * Create a new WebsocketApi handler that can be used to create an
+ * Create a new WebSocketApi handler that can be used to create an
  * authenticated session.
  *
  * @example
  * ```ts
- * export const handler = WebsocketApiHandler({
+ * export const handler = WebSocketApiHandler({
  * })
  * ```
  */
-export function WebsocketApiHandler(cb: Parameters<typeof Handler<"ws">>[1]) {
+export function WebSocketApiHandler(cb: Parameters<typeof Handler<"ws">>[1]) {
   return Handler("ws", async (evt, ctx) => {
     const result = await cb(evt, ctx);
     return result;

--- a/www/docs/constructs/WebSocketApi.about.md
+++ b/www/docs/constructs/WebSocketApi.about.md
@@ -282,6 +282,34 @@ new WebSocketApi(stack, "Api", {
 });
 ```
 
+#### Using [SST Auth](/auth) 
+
+No changes are required for your CDK construct, but inside of your `$connect` and `$default` functions, you can access the authenticated user's information using the hooks provided by Auth.
+
+```ts
+// src/connect.ts
+import { WebSocketApiHandler } from 'sst/node/websocket-api';
+import { useSession } from 'sst/node/auth';
+
+export const handler = WebSocketApiHandler(async () => {
+  const session = useSession();
+  if (session.type === 'public') {
+    return { statusCode: 401};
+  }
+  // Do something here...
+  return {
+    statusCode: 200,
+  };
+});
+
+```
+
+And to connect, remember to set your Authorization Header. Here's an example using [wscat](https://www.npmjs.com/package/wscat).
+
+```sh
+$ wscat -c wss://abcdef123.execute-api.us-west-2.amazonaws.com/production -H "authorization:Bearer jwt-from-auth"
+```
+
 ### Access log
 
 #### Configuring the log format

--- a/www/docs/constructs/v1/WebSocketApi.tsdoc.md
+++ b/www/docs/constructs/v1/WebSocketApi.tsdoc.md
@@ -113,7 +113,7 @@ new WebSocketApi(stack, "Api", {
 
 _Type_ : <span class="mono">Record&lt;<span class="mono">string</span>, <span class='mono'><span class='mono'><span class="mono">string</span> | <span class="mono">[Function](Function#function)</span></span> | <span class="mono">[WebSocketApiFunctionRouteProps](#websocketapifunctionrouteprops)</span></span>&gt;</span>
 
-The routes for the Websocket API
+The routes for the WebSocket API
 
 
 ```js


### PR DESCRIPTION
Similar to how we have the `ApiHandler`, adding a `WebSocketApiHandler` allows access to the `useSession` and all other contexts set from the event and requestContext.

Make sure to import the hooks from the right construct as required.
```ts
import {
  WebSocketApiHandler,
  useHeaders,
  useQueryParam,
} from 'sst/node/websocket-api'; // <-- instead of `sst/node/api`
import { useSession } from 'sst/node/future/auth';

export const handler = WebSocketApiHandler(async () => {
  const session = useSession();
  const headers = useHeaders();
  const params = useQueryParam('hello');
  console.log(session, headers, params);
  return {
    statusCode: 200,
  };
});

```