### PR TITLE
Allow packages to be marked as "internal" for Pothos extractor

### DIFF
--- a/.changeset/chilled-jobs-march.md
+++ b/.changeset/chilled-jobs-march.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+Allow packages to be marked as "internal" for Pothos extractor

--- a/.changeset/nine-dodos-heal.md
+++ b/.changeset/nine-dodos-heal.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+Allow for Pothos extractor to consider some packages as "internal"

--- a/packages/sst/src/cli/commands/plugins/pothos.ts
+++ b/packages/sst/src/cli/commands/plugins/pothos.ts
@@ -20,6 +20,7 @@ export const usePothosBuilder = Context.memo(() => {
     try {
       const schema = await Pothos.generate({
         schema: route.schema,
+        internalPackages: route.internalPackages,
       });
       await fs.writeFile(route.output, schema);
       // bus.publish("pothos.extracted", { file: route.output });

--- a/packages/sst/src/constructs/Api.ts
+++ b/packages/sst/src/constructs/Api.ts
@@ -686,6 +686,10 @@ export interface ApiGraphQLRouteProps<AuthorizerKeys>
      * Commands to run after generating schema. Useful for code generation steps
      */
     commands?: string[];
+    /**
+     * List of packages that should be considered internal during schema generation
+     */
+    internalPackages?: string[];
   };
 }
 
@@ -974,6 +978,7 @@ export class Api<
               route: key,
               fn: getFunctionRef(data.function),
               schema: data.schema,
+              internalPackages: data.internalPackages,
               output: data.output,
               commands: data.commands,
             };
@@ -1481,6 +1486,7 @@ export class Api<
         output: routeProps.pothos?.output,
         schema: routeProps.pothos?.schema,
         commands: routeProps.pothos?.commands,
+        internalPackages: routeProps.pothos?.internalPackages,
       };
     }
 


### PR DESCRIPTION
As mentioned by various people, for example at https://discord.com/channels/983865673656705025/983866416832864350/1080219063252435115, the Pothos extractor fails when importing "internal" packages, for example if I have an Enum type in my `core` package and import it by reference into my `functions` package (`import { MyEnum } from `@myproject/core/file`), that import will be stripped when the Pothos extractor runs.

This is my stab at a solution to this problem, by allowing the user to specify a list of package names that should be considered internal, and subsequently inlined into the schema generated by esbuild. Maybe the naming (and certainly the docstring) could be improved to better clarify the intent of the feature.

