### PR TITLE
fix(remix): delete deprecated options in favor of new supported ones

### DIFF
--- a/.changeset/young-hairs-shout.md
+++ b/.changeset/young-hairs-shout.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+RemixSite: update RemixConfig to prep for Remix v2

--- a/packages/sst/src/constructs/RemixSite.ts
+++ b/packages/sst/src/constructs/RemixSite.ts
@@ -16,7 +16,8 @@ type RemixConfig = {
   assetsBuildDirectory: string;
   publicPath: string;
   serverBuildPath: string;
-  serverBuildTarget: string;
+  serverModuleFormat: string;
+  serverPlatform: string;
   server?: string;
 };
 

--- a/packages/sst/src/constructs/RemixSite.ts
+++ b/packages/sst/src/constructs/RemixSite.ts
@@ -41,7 +41,8 @@ export class RemixSite extends SsrSite {
       assetsBuildDirectory: "public/build",
       publicPath: "/build/",
       serverBuildPath: "build/index.js",
-      serverBuildTarget: "node-cjs",
+      serverModuleFormat: "cjs",
+      serverPlatform: "node",
     };
 
     // Validate config path


### PR DESCRIPTION
The previous options `serverBuildTarget` were deprecated in favor of a combination of options from the remix config, this PR deletes the deprecated ones and adds the new ones to maintain the same behavior

More info: https://remix.run/docs/en/1.16.0/pages/v2#node-cjs