### PR TITLE
[Fix/Dotnet]: enable the selection of dotnet6 bootstrap and secure input.out with quotes 

### DIFF
--- a/.changeset/funny-panthers-cover.md
+++ b/.changeset/funny-panthers-cover.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+[Fix/Dotnet]: enable the selection of dotnet6 bootstrap and secure input.out with quotes 

--- a/packages/sst/src/runtime/handlers.ts
+++ b/packages/sst/src/runtime/handlers.ts
@@ -32,6 +32,7 @@ interface StartWorkerInput {
   environment: Record<string, string>;
   out: string;
   handler: string;
+  runtime: string;
 }
 
 interface ShouldBuildInput {

--- a/packages/sst/src/runtime/handlers/dotnet.ts
+++ b/packages/sst/src/runtime/handlers/dotnet.ts
@@ -49,7 +49,7 @@ export const useDotnetHandler = Context.memo(async () => {
           `exec`,
           url.fileURLToPath(
             new URL(
-              `../../support/${BOOTSTRAP_MAP["dotnetcore3.1"]}/release/dotnet-bootstrap.dll`,
+              `../../support/${BOOTSTRAP_MAP[input.runtime]}/release/dotnet-bootstrap.dll`,
               import.meta.url
             )
           ),
@@ -95,7 +95,7 @@ export const useDotnetHandler = Context.memo(async () => {
             "dotnet",
             "publish",
             "--output",
-            input.out,
+            "\"" + input.out + "\"",
             "--configuration",
             "Release",
             "--framework",
@@ -120,6 +120,7 @@ export const useDotnetHandler = Context.memo(async () => {
         return {
           type: "success",
           handler: input.props.handler!,
+          runtime: input.props.runtime
         };
       } catch (ex: any) {
         return {


### PR DESCRIPTION
This PR addresses the issue described in [issue2836](https://github.com/serverless-stack/sst/issues/2836), enabling the selection of .NET 6 bootstrap and ensuring the safety of input.out by utilizing quotes