### PR TITLE
Job: Add support for runtime setup commands

### DIFF
--- a/packages/sst/test/constructs/Job.test.ts
+++ b/packages/sst/test/constructs/Job.test.ts
@@ -162,6 +162,26 @@ test("constructor: environment", async () => {
   });
 });
 
+test("constructor: setupCommands", async () => {
+  const app = await createApp({
+    mode: "deploy",
+  });
+  const stack = new Stack(app, "stack");
+  new Job(stack, "Job", {
+    handler: "test/constructs/lambda.handler",
+    setupCommands: [
+      "yarn install google-chrome"
+    ]
+  });
+  await app.finish();
+  // Invoker needs to call CodeBuild on `sst start`
+  hasResource(stack, "AWS::CodeBuild::Project", {
+    Source: objectLike({
+      BuildSpec: stringLike(/commands:\n\s+- yarn install google-chrome\n\s+- node handler-wrapper.mjs/),
+    }),
+  });
+});
+
 test("constructor: cdk.vpc", async () => {
   const stack = new Stack(await createApp(), "stack");
   new Job(stack, "Job", {


### PR DESCRIPTION
This commit adds support for running commands inside the Job runtime environment before the actual node entrypoint. This allows users to run setup commands such as installing packages or missing libraries without having to modify the lambda base image.

We have this requirement on a project where we don't want to modify the lambda images but still need to run simple setup tasks.

Thanks.