### PR TITLE
bug: Dev role defined for the function cannot be assumed by Lambda

### DIFF
--- a/.changeset/weak-books-design.md
+++ b/.changeset/weak-books-design.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+SsrSite: Fix The role defined for the function cannot be assumed by Lambda.

--- a/.changeset/weak-books-design.md
+++ b/.changeset/weak-books-design.md
@@ -2,4 +2,4 @@
 "sst": patch
 ---
 
-SsrSite: Fix The role defined for the function cannot be assumed by Lambda.
+SsrSite: Fix dev server role cannot be assumed by Lambda

--- a/packages/sst/src/constructs/SsrSite.ts
+++ b/packages/sst/src/constructs/SsrSite.ts
@@ -25,7 +25,9 @@ import {
   Effect,
   Policy,
   PolicyStatement,
+  AccountPrincipal,
   ServicePrincipal,
+  CompositePrincipal,
 } from "aws-cdk-lib/aws-iam";
 import {
   Architecture,
@@ -775,7 +777,10 @@ export class SsrSite extends Construct implements SSTConstruct {
 
     const app = this.node.root as App;
     const role = new Role(this, "ServerFunctionRole", {
-      assumedBy: new ServicePrincipal("lambda.amazonaws.com"),
+      assumedBy: new CompositePrincipal(
+        new AccountPrincipal(app.account),
+        new ServicePrincipal("lambda.amazonaws.com")
+      ),
       maxSessionDuration: CdkDuration.hours(12),
     });
 

--- a/packages/sst/src/constructs/SsrSite.ts
+++ b/packages/sst/src/constructs/SsrSite.ts
@@ -25,7 +25,7 @@ import {
   Effect,
   Policy,
   PolicyStatement,
-  AccountPrincipal,
+  ServicePrincipal,
 } from "aws-cdk-lib/aws-iam";
 import {
   Architecture,
@@ -775,7 +775,7 @@ export class SsrSite extends Construct implements SSTConstruct {
 
     const app = this.node.root as App;
     const role = new Role(this, "ServerFunctionRole", {
-      assumedBy: new AccountPrincipal(app.account),
+      assumedBy: new ServicePrincipal("lambda.amazonaws.com"),
       maxSessionDuration: CdkDuration.hours(12),
     });
 


### PR DESCRIPTION
This change resolves #2848 by specifying the Lambda Service Policy when creating the lambda function for the SsrSite server.