### PR TITLE
docs(SsrSite): generalise attachPermissions

### DIFF
--- a/packages/sst/src/constructs/SsrSite.ts
+++ b/packages/sst/src/constructs/SsrSite.ts
@@ -439,8 +439,8 @@ export class SsrSite extends Construct implements SSTConstruct {
   /////////////////////
 
   /**
-   * Attaches the given list of permissions to allow the Astro server side
-   * rendering to access other AWS resources.
+   * Attaches the given list of permissions to allow the server side
+   * rendering framework to access other AWS resources.
    *
    * @example
    * ```js


### PR DESCRIPTION
The other SSR frameworks that extend the attachPermissions method has the mention of Astro, even though they are not using Astro. See SvelteKit as example:
https://docs.sst.dev/constructs/SvelteKitSite#attachpermissions
This simply generalises to "framework" instead in the docstring