### PR TITLE
Fix: header values not getting parsed in edge

### DIFF
--- a/.changeset/purple-ants-march.md
+++ b/.changeset/purple-ants-march.md
@@ -1,0 +1,5 @@
+---
+"solid-start-sst": patch
+---
+
+SolidStartSite: fix parsing CloudFront headers

--- a/packages/solid-start-sst/entry-edge.mjs
+++ b/packages/solid-start-sst/entry-edge.mjs
@@ -37,8 +37,8 @@ function createRequest(event) {
 
   // Build headers
   const headers = new Headers();
-  for (const [key, value] of Object.entries(record.request.headers)) {
-    headers.append(key, value[0]);
+  for (const [key, headerVal] of Object.entries(record.request.headers)) {
+    headers.append(key, headerVal[0].value);
   }
 
   return new Request(url, {

--- a/packages/solid-start-sst/entry-edge.mjs
+++ b/packages/solid-start-sst/entry-edge.mjs
@@ -37,8 +37,8 @@ function createRequest(event) {
 
   // Build headers
   const headers = new Headers();
-  for (const [key, headerVal] of Object.entries(record.request.headers)) {
-    headers.append(key, headerVal[0].value);
+  for (const [key, values] of Object.entries(record.request.headers)) {
+    headers.append(key, values[0].value);
   }
 
   return new Request(url, {


### PR DESCRIPTION
Cloudfront edge lambda headers need to be accessed via `.value`