### PR TITLE
[Fix/Parallel Project Init]: Skip cleanup of very recent config files

### DIFF
--- a/.changeset/chilled-books-learn.md
+++ b/.changeset/chilled-books-learn.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+Cli: do not remove config files created by concurrent SST processes

--- a/packages/sst/src/project.ts
+++ b/packages/sst/src/project.ts
@@ -165,6 +165,8 @@ export async function initProject(globals: GlobalOptions) {
     const files = await fs.readdir(project.paths.root);
     for (const file of files) {
       if (file.startsWith(".sst.config")) {
+        // Do not remove recently generated config files. This allows for multiple
+        // SST processes to run concurrently.
         const timeGenerated = (file.match(/\b\d{13}\b/g) ?? []).at(0);
         if (timeGenerated && Date.now() - parseInt(timeGenerated, 10) < 30000) {
           continue;

--- a/packages/sst/src/project.ts
+++ b/packages/sst/src/project.ts
@@ -165,6 +165,10 @@ export async function initProject(globals: GlobalOptions) {
     const files = await fs.readdir(project.paths.root);
     for (const file of files) {
       if (file.startsWith(".sst.config")) {
+        const timeGenerated = (file.match(/\b\d{13}\b/g) ?? []).at(0);
+        if (timeGenerated && Date.now() - parseInt(timeGenerated, 10) < 30000) {
+          continue;
+        }
         await fs.unlink(path.join(project.paths.root, file));
         Logger.debug(`Removed old config file ${file}`);
       }


### PR DESCRIPTION
Aims to solve 
https://discord.com/channels/983865673656705025/1106299750636068946

Tries to avoid the situation where another sst process is spawned before another one finishes then the first one deletes the config files of the other parallel process