### PR TITLE
chore: replace zip-local with adm-zip

### DIFF
--- a/.changeset/shaggy-panthers-vanish.md
+++ b/.changeset/shaggy-panthers-vanish.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+Replace zip-local package with adm-zip

--- a/packages/sst/package.json
+++ b/packages/sst/package.json
@@ -57,6 +57,7 @@
     "@babel/core": "^7.0.0-0",
     "@babel/generator": "^7.20.5",
     "@trpc/server": "9.16.0",
+    "adm-zip": "^0.5.10",
     "aws-cdk-lib": "2.72.1",
     "aws-iot-device-sdk": "^2.2.12",
     "aws-sdk": "^2.1326.0",
@@ -94,8 +95,7 @@
     "undici": "^5.12.0",
     "uuid": "^9.0.0",
     "ws": "^8.11.0",
-    "yargs": "^17.6.2",
-    "zip-local": "^0.3.5"
+    "yargs": "^17.6.2"
   },
   "devDependencies": {
     "@aws-sdk/client-api-gateway": "^3.208.0",
@@ -119,7 +119,6 @@
     "@types/uuid": "^8.3.4",
     "@types/ws": "^8.5.3",
     "@types/yargs": "^17.0.13",
-    "adm-zip": "^0.5.10",
     "archiver": "^5.3.1",
     "tsx": "^3.12.1",
     "typescript": "^4.9.5",

--- a/packages/sst/src/runtime/handlers/java.ts
+++ b/packages/sst/src/runtime/handlers/java.ts
@@ -4,13 +4,13 @@ import os from "os";
 import { useRuntimeHandlers } from "../handlers.js";
 import { useRuntimeWorkers } from "../workers.js";
 import { Context } from "../../context/context.js";
-import zipLocal from "zip-local";
 import { ChildProcessWithoutNullStreams, spawn } from "child_process";
 import { useRuntimeServerConfig } from "../server.js";
 import { existsAsync, findBelow, isChild } from "../../util/fs.js";
 import { useProject } from "../../project.js";
 import { execAsync } from "../../util/process.js";
 import url from "url";
+import AdmZip from "adm-zip";
 
 export const useJavaHandler = Context.memo(async () => {
   const workers = await useRuntimeWorkers();
@@ -89,7 +89,7 @@ export const useJavaHandler = Context.memo(async () => {
         const zip = (await fs.readdir(buildOutput)).find((f) =>
           f.endsWith(".zip")
         )!;
-        zipLocal.sync.unzip(path.join(buildOutput, zip)).save(input.out);
+        new AdmZip(path.join(buildOutput, zip)).extractAllTo(input.out);
         return {
           type: "success",
           handler: input.props.handler!,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,7 +64,7 @@ importers:
         version: 3.43.0
       '@aws-sdk/client-s3':
         specifier: 3.43.0
-        version: 3.43.0(@aws-sdk/signature-v4-crt@3.292.0)
+        version: 3.43.0
       '@aws-sdk/client-ssm':
         specifier: 3.43.0
         version: 3.43.0
@@ -73,7 +73,7 @@ importers:
         version: 3.257.0
       '@aws-sdk/s3-request-presigner':
         specifier: 3.43.0
-        version: 3.43.0(@aws-sdk/signature-v4-crt@3.292.0)
+        version: 3.43.0
       '@aws-sdk/util-dynamodb':
         specifier: ^3.52.0
         version: 3.208.0
@@ -124,10 +124,10 @@ importers:
         version: 1.2.8(react@17.0.2)
       '@trpc/client':
         specifier: 9.18.0
-        version: 9.18.0(@trpc/server@9.18.0)
+        version: 9.18.0
       '@trpc/react':
         specifier: 9.18.0
-        version: 9.18.0(@trpc/client@9.18.0)(@trpc/server@9.18.0)(react-dom@17.0.2)(react-query@3.39.2)(react@17.0.2)
+        version: 9.18.0(@trpc/client@9.18.0)(react-dom@17.0.2)(react-query@3.39.2)(react@17.0.2)
       ace-builds:
         specifier: ^1.4.13
         version: 1.12.5
@@ -148,7 +148,7 @@ importers:
         version: 9.0.16
       jotai:
         specifier: ^1.4.7
-        version: 1.9.2(@babel/core@7.21.3)(immer@9.0.16)(react@17.0.2)
+        version: 1.9.2(immer@9.0.16)(react@17.0.2)
       react:
         specifier: ^17.0.2
         version: 17.0.2
@@ -181,7 +181,7 @@ importers:
         version: 6.4.3(react-dom@17.0.2)(react@17.0.2)
       react-spinners:
         specifier: ^0.11.0
-        version: 0.11.0(@babel/core@7.21.3)(@types/react@17.0.52)(react-dom@17.0.2)(react@17.0.2)
+        version: 0.11.0(@types/react@17.0.52)(react-dom@17.0.2)(react@17.0.2)
       react-textarea-autosize:
         specifier: ^8.4.0
         version: 8.4.0(@types/react@17.0.52)(react@17.0.2)
@@ -274,7 +274,7 @@ importers:
     devDependencies:
       solid-start:
         specifier: 0.2.11
-        version: 0.2.11(@solidjs/meta@0.28.5)(@solidjs/router@0.6.0)(solid-js@1.7.5)(vite@3.2.5)
+        version: 0.2.11(vite@3.2.5)
       vite:
         specifier: ^3.1.8
         version: 3.2.5(terser@5.15.1)
@@ -350,6 +350,9 @@ importers:
       '@trpc/server':
         specifier: 9.16.0
         version: 9.16.0
+      adm-zip:
+        specifier: ^0.5.10
+        version: 0.5.10
       aws-cdk-lib:
         specifier: 2.72.1
         version: 2.72.1(constructs@10.1.156)
@@ -464,9 +467,6 @@ importers:
       yargs:
         specifier: ^17.6.2
         version: 17.6.2
-      zip-local:
-        specifier: ^0.3.5
-        version: 0.3.5
     devDependencies:
       '@aws-sdk/client-api-gateway':
         specifier: ^3.208.0
@@ -531,9 +531,6 @@ importers:
       '@types/yargs':
         specifier: ^17.0.13
         version: 17.0.13
-      adm-zip:
-        specifier: ^0.5.10
-        version: 0.5.10
       archiver:
         specifier: ^5.3.1
         version: 5.3.1
@@ -548,276 +545,11 @@ importers:
         version: 0.28.3
     publishDirectory: dist
 
-  packages/sst/dist:
-    dependencies:
-      '@aws-cdk/aws-apigatewayv2-alpha':
-        specifier: ^2.62.2-alpha.0
-        version: 2.62.2-alpha.0(aws-cdk-lib@2.62.2)(constructs@10.1.156)
-      '@aws-cdk/aws-apigatewayv2-authorizers-alpha':
-        specifier: ^2.62.2-alpha.0
-        version: 2.62.2-alpha.0(@aws-cdk/aws-apigatewayv2-alpha@2.62.2-alpha.0)(aws-cdk-lib@2.62.2)(constructs@10.1.156)
-      '@aws-cdk/aws-apigatewayv2-integrations-alpha':
-        specifier: ^2.62.2-alpha.0
-        version: 2.62.2-alpha.0(@aws-cdk/aws-apigatewayv2-alpha@2.62.2-alpha.0)(aws-cdk-lib@2.62.2)(constructs@10.1.156)
-      '@aws-cdk/cloud-assembly-schema':
-        specifier: 2.62.2
-        version: 2.62.2
-      '@aws-cdk/cloudformation-diff':
-        specifier: 2.62.2
-        version: 2.62.2
-      '@aws-cdk/cx-api':
-        specifier: 2.62.2
-        version: 2.62.2(@aws-cdk/cloud-assembly-schema@2.62.2)
-      '@aws-sdk/client-cloudformation':
-        specifier: ^3.279.0
-        version: 3.279.0
-      '@aws-sdk/client-iot':
-        specifier: ^3.279.0
-        version: 3.279.0
-      '@aws-sdk/client-iot-data-plane':
-        specifier: ^3.279.0
-        version: 3.279.0
-      '@aws-sdk/client-lambda':
-        specifier: ^3.279.0
-        version: 3.279.0
-      '@aws-sdk/client-rds-data':
-        specifier: ^3.279.0
-        version: 3.279.0
-      '@aws-sdk/client-s3':
-        specifier: ^3.279.0
-        version: 3.279.0(@aws-sdk/signature-v4-crt@3.292.0)
-      '@aws-sdk/client-ssm':
-        specifier: ^3.279.0
-        version: 3.279.0
-      '@aws-sdk/client-sts':
-        specifier: ^3.279.0
-        version: 3.279.0
-      '@aws-sdk/config-resolver':
-        specifier: ^3.272.0
-        version: 3.272.0
-      '@aws-sdk/credential-providers':
-        specifier: ^3.279.0
-        version: 3.279.0
-      '@aws-sdk/middleware-retry':
-        specifier: ^3.272.0
-        version: 3.272.0
-      '@aws-sdk/middleware-signing':
-        specifier: ^3.272.0
-        version: 3.272.0
-      '@aws-sdk/signature-v4-crt':
-        specifier: ^3.272.0
-        version: 3.292.0
-      '@aws-sdk/smithy-client':
-        specifier: ^3.279.0
-        version: 3.279.0
-      '@babel/core':
-        specifier: ^7.0.0-0
-        version: 7.12.9
-      '@babel/generator':
-        specifier: ^7.20.5
-        version: 7.20.5
-      '@trpc/server':
-        specifier: 9.16.0
-        version: 9.16.0
-      aws-cdk-lib:
-        specifier: 2.62.2
-        version: 2.62.2(constructs@10.1.156)
-      aws-iot-device-sdk:
-        specifier: ^2.2.12
-        version: 2.2.12
-      aws-sdk:
-        specifier: ^2.1326.0
-        version: 2.1326.0
-      builtin-modules:
-        specifier: 3.2.0
-        version: 3.2.0
-      cdk-assets:
-        specifier: 2.62.2
-        version: 2.62.2
-      chalk:
-        specifier: ^5.2.0
-        version: 5.2.0
-      chokidar:
-        specifier: ^3.5.3
-        version: 3.5.3
-      ci-info:
-        specifier: ^3.7.0
-        version: 3.7.0
-      colorette:
-        specifier: ^2.0.19
-        version: 2.0.19
-      conf:
-        specifier: ^10.2.0
-        version: 10.2.0
-      constructs:
-        specifier: 10.1.156
-        version: 10.1.156
-      cross-spawn:
-        specifier: ^7.0.3
-        version: 7.0.3
-      dendriform-immer-patch-optimiser:
-        specifier: ^2.1.0
-        version: 2.1.3(immer@9.0.16)
-      dotenv:
-        specifier: ^16.0.3
-        version: 16.0.3
-      esbuild:
-        specifier: 0.16.13
-        version: 0.16.13
-      express:
-        specifier: ^4.18.2
-        version: 4.18.2
-      fast-jwt:
-        specifier: ^1.6.1
-        version: 1.7.1
-      get-port:
-        specifier: ^6.1.2
-        version: 6.1.2
-      glob:
-        specifier: ^8.0.3
-        version: 8.0.3
-      graphql:
-        specifier: '*'
-        version: 16.6.0
-      graphql-helix:
-        specifier: ^1.12.0
-        version: 1.12.0(graphql@16.6.0)
-      immer:
-        specifier: '9'
-        version: 9.0.16
-      ink:
-        specifier: ^4.0.0
-        version: 4.0.0(@types/react@17.0.52)(react@18.2.0)
-      ink-spinner:
-        specifier: ^5.0.0
-        version: 5.0.0(ink@4.0.0)(react@18.2.0)
-      kysely:
-        specifier: ^0.23.4
-        version: 0.23.5
-      kysely-codegen:
-        specifier: ^0.9.0
-        version: 0.9.0(kysely@0.23.5)
-      kysely-data-api:
-        specifier: ^0.2.0
-        version: 0.2.1(@aws-sdk/client-rds-data@3.279.0)(kysely@0.23.5)
-      minimatch:
-        specifier: ^6.1.6
-        version: 6.1.6
-      openid-client:
-        specifier: ^5.1.8
-        version: 5.3.0
-      ora:
-        specifier: ^6.1.2
-        version: 6.1.2
-      react:
-        specifier: 18.2.0
-        version: 18.2.0
-      remeda:
-        specifier: ^1.3.0
-        version: 1.3.0
-      sst-aws-cdk:
-        specifier: 2.62.2-3
-        version: 2.62.2-3
-      undici:
-        specifier: ^5.12.0
-        version: 5.12.0
-      uuid:
-        specifier: ^9.0.0
-        version: 9.0.0
-      ws:
-        specifier: ^8.11.0
-        version: 8.11.0
-      yargs:
-        specifier: ^17.6.2
-        version: 17.6.2
-      zip-local:
-        specifier: ^0.3.5
-        version: 0.3.5
-    devDependencies:
-      '@aws-sdk/client-api-gateway':
-        specifier: ^3.208.0
-        version: 3.208.0
-      '@aws-sdk/client-cloudfront':
-        specifier: ^3.279.0
-        version: 3.279.0
-      '@aws-sdk/client-codebuild':
-        specifier: ^3.279.0
-        version: 3.279.0
-      '@aws-sdk/client-iam':
-        specifier: ^3.279.0
-        version: 3.279.0
-      '@aws-sdk/types':
-        specifier: ^3.272.0
-        version: 3.272.0
-      '@graphql-tools/merge':
-        specifier: ^8.3.16
-        version: 8.3.16(graphql@16.6.0)
-      '@sls-next/lambda-at-edge':
-        specifier: ^3.7.0
-        version: 3.7.0(@aws-sdk/signature-v4-crt@3.292.0)(@babel/core@7.12.9)(builtin-modules@3.2.0)(typescript@4.9.5)
-      '@tsconfig/node16':
-        specifier: ^1.0.3
-        version: 1.0.3
-      '@types/adm-zip':
-        specifier: ^0.5.0
-        version: 0.5.0
-      '@types/aws-iot-device-sdk':
-        specifier: ^2.2.4
-        version: 2.2.4
-      '@types/aws-lambda':
-        specifier: ^8.10.108
-        version: 8.10.108
-      '@types/babel__core':
-        specifier: ^7.1.20
-        version: 7.1.20
-      '@types/babel__generator':
-        specifier: ^7.6.4
-        version: 7.6.4
-      '@types/cross-spawn':
-        specifier: ^6.0.2
-        version: 6.0.2
-      '@types/express':
-        specifier: ^4.17.14
-        version: 4.17.14
-      '@types/glob':
-        specifier: ^8.0.0
-        version: 8.0.0
-      '@types/node':
-        specifier: ^18.11.9
-        version: 18.11.9
-      '@types/react':
-        specifier: ^17.0.33
-        version: 17.0.52
-      '@types/uuid':
-        specifier: ^8.3.4
-        version: 8.3.4
-      '@types/ws':
-        specifier: ^8.5.3
-        version: 8.5.3
-      '@types/yargs':
-        specifier: ^17.0.13
-        version: 17.0.13
-      adm-zip:
-        specifier: ^0.5.10
-        version: 0.5.10
-      archiver:
-        specifier: ^5.3.1
-        version: 5.3.1
-      tsx:
-        specifier: ^3.12.1
-        version: 3.12.1
-      typescript:
-        specifier: ^4.9.5
-        version: 4.9.5
-      vitest:
-        specifier: ^0.28.3
-        version: 0.28.3
-
   packages/svelte-kit-sst:
     devDependencies:
       '@sveltejs/kit':
         specifier: ^1.5.0
-        version: 1.16.2(svelte@3.59.1)(vite@4.1.4)
+        version: 1.16.2
       '@types/aws-lambda':
         specifier: ^8.10.112
         version: 8.10.112
@@ -835,7 +567,7 @@ importers:
         version: 2.0.0-beta.18(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5)
       '@docusaurus/preset-classic':
         specifier: 2.0.0-beta.18
-        version: 2.0.0-beta.18(@algolia/client-search@4.14.2)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5)
+        version: 2.0.0-beta.18(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5)
       '@jridgewell/gen-mapping':
         specifier: ^0.3.2
         version: 0.3.2
@@ -873,14 +605,13 @@ packages:
       '@algolia/autocomplete-shared': 1.7.2
     dev: false
 
-  /@algolia/autocomplete-preset-algolia@1.7.2(@algolia/client-search@4.14.2)(algoliasearch@4.14.2):
+  /@algolia/autocomplete-preset-algolia@1.7.2(algoliasearch@4.14.2):
     resolution: {integrity: sha512-+RYEG6B0QiGGfRb2G3MtPfyrl0dALF3cQNTWBzBX6p5o01vCCGTTinAm2UKG3tfc2CnOMAtnPLkzNZyJUpnVJw==}
     peerDependencies:
       '@algolia/client-search': '>= 4.9.1 < 6'
       algoliasearch: '>= 4.9.1 < 6'
     dependencies:
       '@algolia/autocomplete-shared': 1.7.2
-      '@algolia/client-search': 4.14.2
       algoliasearch: 4.14.2
     dev: false
 
@@ -1079,17 +810,6 @@ packages:
     resolution: {integrity: sha512-4UbI4+bH7+R+3R9S1td2Csrzrh6/swaEHNy2/2PSGPyleZZWsu7jCH57ZCdUSVQ1j0QR8S0XHrfjv6jsYMvrxQ==}
     dev: false
 
-  /@aws-cdk/aws-apigatewayv2-alpha@2.62.2-alpha.0(aws-cdk-lib@2.62.2)(constructs@10.1.156):
-    resolution: {integrity: sha512-MHnUWA846ksR8KNcxSGsrKCpUWuQfjwFiMyJE6gf2BugyDTtmdJCxWv7YAxk26s5hg87+JPqZ7VLPmxysBJvBg==}
-    engines: {node: '>= 14.15.0'}
-    peerDependencies:
-      aws-cdk-lib: ^2.62.2
-      constructs: ^10.0.0
-    dependencies:
-      aws-cdk-lib: 2.62.2(constructs@10.1.156)
-      constructs: 10.1.156
-    dev: false
-
   /@aws-cdk/aws-apigatewayv2-alpha@2.72.1-alpha.0(aws-cdk-lib@2.72.1)(constructs@10.1.156):
     resolution: {integrity: sha512-3DIUZjqLsPEzewlbXyYXrhrVPfQV+VR4sU1slgwXal/D27+PuM/E3g6R2Oq3V9mwaSrJaTlGP0o+y5i8o/aQtQ==}
     engines: {node: '>= 14.15.0'}
@@ -1098,19 +818,6 @@ packages:
       constructs: ^10.0.0
     dependencies:
       aws-cdk-lib: 2.72.1(constructs@10.1.156)
-      constructs: 10.1.156
-    dev: false
-
-  /@aws-cdk/aws-apigatewayv2-authorizers-alpha@2.62.2-alpha.0(@aws-cdk/aws-apigatewayv2-alpha@2.62.2-alpha.0)(aws-cdk-lib@2.62.2)(constructs@10.1.156):
-    resolution: {integrity: sha512-QdFgtxHBWFmIu1uTJBlOqKS5BFD8iM2/JlEUSHMZoYNJ4fqmKQV3Ffi+RIEQNTvQ2fCARl3u0/QWEmbaUiZxzg==}
-    engines: {node: '>= 14.15.0'}
-    peerDependencies:
-      '@aws-cdk/aws-apigatewayv2-alpha': 2.62.2-alpha.0
-      aws-cdk-lib: ^2.62.2
-      constructs: ^10.0.0
-    dependencies:
-      '@aws-cdk/aws-apigatewayv2-alpha': 2.62.2-alpha.0(aws-cdk-lib@2.62.2)(constructs@10.1.156)
-      aws-cdk-lib: 2.62.2(constructs@10.1.156)
       constructs: 10.1.156
     dev: false
 
@@ -1127,19 +834,6 @@ packages:
       constructs: 10.1.156
     dev: false
 
-  /@aws-cdk/aws-apigatewayv2-integrations-alpha@2.62.2-alpha.0(@aws-cdk/aws-apigatewayv2-alpha@2.62.2-alpha.0)(aws-cdk-lib@2.62.2)(constructs@10.1.156):
-    resolution: {integrity: sha512-dfqtZQhf1dnzaWCEjAB2PUvG4ftyaBbeEgsaHXsRduOf8TanSbpbbenP857+Q17t6V11cs41WZK3u8AEfudxzQ==}
-    engines: {node: '>= 14.15.0'}
-    peerDependencies:
-      '@aws-cdk/aws-apigatewayv2-alpha': 2.62.2-alpha.0
-      aws-cdk-lib: ^2.62.2
-      constructs: ^10.0.0
-    dependencies:
-      '@aws-cdk/aws-apigatewayv2-alpha': 2.62.2-alpha.0(aws-cdk-lib@2.62.2)(constructs@10.1.156)
-      aws-cdk-lib: 2.62.2(constructs@10.1.156)
-      constructs: 10.1.156
-    dev: false
-
   /@aws-cdk/aws-apigatewayv2-integrations-alpha@2.72.1-alpha.0(@aws-cdk/aws-apigatewayv2-alpha@2.72.1-alpha.0)(aws-cdk-lib@2.72.1)(constructs@10.1.156):
     resolution: {integrity: sha512-KbPy/P6BduZZ32E0xzm1EobGAhgMklWPfSJ1DGQ8eKZ9KhcP1BoDqbA7zg8TnI84QAItArvMfai3XYe9Q78gjA==}
     engines: {node: '>= 14.15.0'}
@@ -1153,27 +847,12 @@ packages:
       constructs: 10.1.156
     dev: false
 
-  /@aws-cdk/cfnspec@2.62.2:
-    resolution: {integrity: sha512-/Fohjzce9FCb+fGFev8J4rHOFvdRgQbnMPIshlSaYSTAXLDBkX6CCb+WjeI6Lo8nTbTTvRQiCDTnnDgKPzz8OA==}
-    dependencies:
-      fs-extra: 9.1.0
-      md5: 2.3.0
-    dev: false
-
   /@aws-cdk/cfnspec@2.72.1:
     resolution: {integrity: sha512-qF6zQXXJPpRwI3uS5+whGtJdQFwxH7gSwW6Xa8xdXWWEUazDEgKOLt9isw8As8vH8bCRAxukOkogGq1+xMG30w==}
     dependencies:
       fs-extra: 9.1.0
       md5: 2.3.0
     dev: false
-
-  /@aws-cdk/cloud-assembly-schema@2.62.2:
-    resolution: {integrity: sha512-oOjNdy9nZoz+dhuK/YBrfaT+ts2ge+RCy+9BtiFIspD0G+xkGODFB6pfIua6CnROWePEzhdEOpyZSJmqlc+XBw==}
-    engines: {node: '>= 14.15.0'}
-    dev: false
-    bundledDependencies:
-      - jsonschema
-      - semver
 
   /@aws-cdk/cloud-assembly-schema@2.72.1:
     resolution: {integrity: sha512-sffYNtKZbhGACfRX6BnDlp4ruHaqkuElwEnMIaiaih4ro2Z0+a960wKkpC6P5tKf/KWUkNocu91qeKgqvIxYmA==}
@@ -1186,19 +865,6 @@ packages:
       - jsonschema
       - semver
 
-  /@aws-cdk/cloudformation-diff@2.62.2:
-    resolution: {integrity: sha512-xknbQyTykLha7lCw+OpUS/7m33DdwDSuK+xZjsIIz9Hu4B7exWylefD9SERlO9xENInVW416zJ0EvxTodpTw/A==}
-    engines: {node: '>= 14.15.0'}
-    dependencies:
-      '@aws-cdk/cfnspec': 2.62.2
-      '@types/node': 14.18.46
-      chalk: 4.1.2
-      diff: 5.1.0
-      fast-deep-equal: 3.1.3
-      string-width: 4.2.3
-      table: 6.8.1
-    dev: false
-
   /@aws-cdk/cloudformation-diff@2.72.1:
     resolution: {integrity: sha512-Clou31yR6xNEcaxJx8+PCNRmqMEWEh9F59txjC9UlvtWCGHNi94LsScdunJRTFIwoiUNxXrNWQFZrOq362+RbA==}
     engines: {node: '>= 14.15.0'}
@@ -1210,17 +876,6 @@ packages:
       string-width: 4.2.3
       table: 6.8.1
     dev: false
-
-  /@aws-cdk/cx-api@2.62.2(@aws-cdk/cloud-assembly-schema@2.62.2):
-    resolution: {integrity: sha512-RA3lSK3I5y1Nr2f1BBZgovTT0Vx8T9kz4tcbBln7efan+sZX7WEAIUkwSY+Vi5n8kZN8D62yhtJ0UVGO9OYB3w==}
-    engines: {node: '>= 14.15.0'}
-    peerDependencies:
-      '@aws-cdk/cloud-assembly-schema': 2.62.2
-    dependencies:
-      '@aws-cdk/cloud-assembly-schema': 2.62.2
-    dev: false
-    bundledDependencies:
-      - semver
 
   /@aws-cdk/cx-api@2.72.1(@aws-cdk/cloud-assembly-schema@2.72.1):
     resolution: {integrity: sha512-ATNdCF0mqXvF1oj0B4SD7gcadOqt12y1jt1agtor4CKw3C3hH4gjG5CuRvtY5F4Sc1YEhssE7y8gtr6WJgYsCA==}
@@ -2206,7 +1861,7 @@ packages:
       - aws-crt
     dev: false
 
-  /@aws-sdk/client-s3@3.43.0(@aws-sdk/signature-v4-crt@3.292.0):
+  /@aws-sdk/client-s3@3.43.0:
     resolution: {integrity: sha512-RwO5aaeg920USk5mEjHvZvWixAOmz8BUXutb0jP6f8Eg5BCnf94AZ0sIRHyQ7Agw+V1A/tMhM0zfs26bsAfKUw==}
     engines: {node: '>=10.0.0'}
     dependencies:
@@ -2232,7 +1887,7 @@ packages:
       '@aws-sdk/middleware-location-constraint': 3.40.0
       '@aws-sdk/middleware-logger': 3.40.0
       '@aws-sdk/middleware-retry': 3.40.0
-      '@aws-sdk/middleware-sdk-s3': 3.41.0(@aws-sdk/signature-v4-crt@3.292.0)
+      '@aws-sdk/middleware-sdk-s3': 3.41.0
       '@aws-sdk/middleware-serde': 3.40.0
       '@aws-sdk/middleware-signing': 3.40.0
       '@aws-sdk/middleware-ssec': 3.40.0
@@ -3939,7 +3594,7 @@ packages:
       tslib: 2.5.0
     dev: false
 
-  /@aws-sdk/middleware-sdk-s3@3.41.0(@aws-sdk/signature-v4-crt@3.292.0):
+  /@aws-sdk/middleware-sdk-s3@3.41.0:
     resolution: {integrity: sha512-B7JOpmIpm1zxERQEMwZCWj3FisTvwfUgpfQglYdqrB6VpIoCM8fk2pmi5KzU/JDeNBlhTouj6mwnhJL/z5jopA==}
     engines: {node: '>= 10.0.0'}
     peerDependencies:
@@ -3947,7 +3602,6 @@ packages:
     dependencies:
       '@aws-sdk/protocol-http': 3.40.0
       '@aws-sdk/signature-v4': 3.40.0
-      '@aws-sdk/signature-v4-crt': 3.292.0
       '@aws-sdk/types': 3.40.0
       '@aws-sdk/util-arn-parser': 3.37.0
       tslib: 2.5.0
@@ -4419,11 +4073,11 @@ packages:
       tslib: 2.5.0
     dev: true
 
-  /@aws-sdk/s3-request-presigner@3.43.0(@aws-sdk/signature-v4-crt@3.292.0):
+  /@aws-sdk/s3-request-presigner@3.43.0:
     resolution: {integrity: sha512-Nc9yAWHE64ocC4Y8uZBjXvD5fIsYkhm52J3NbEbn8jIKx+JOLzw97FEw5bil53Z2v/B+dUE/2r0Vh2g4EP67Ag==}
     engines: {node: '>= 10.0.0'}
     dependencies:
-      '@aws-sdk/middleware-sdk-s3': 3.41.0(@aws-sdk/signature-v4-crt@3.292.0)
+      '@aws-sdk/middleware-sdk-s3': 3.41.0
       '@aws-sdk/protocol-http': 3.40.0
       '@aws-sdk/signature-v4': 3.40.0
       '@aws-sdk/smithy-client': 3.41.0
@@ -5313,6 +4967,7 @@ packages:
       source-map: 0.5.7
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /@babel/core@7.20.2:
     resolution: {integrity: sha512-w7DbG8DtMrJcFOi4VrLm+8QM4az8Mo+PuLBKLp2zrYRCow8W/f9xiXm5sN53C8HksCyDQwCKha9JiDoIyPjT2g==}
@@ -6274,16 +5929,6 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-syntax-jsx@7.14.5(@babel/core@7.12.9):
-    resolution: {integrity: sha512-ohuFIsOMXJnbOMRfX7/w7LocdR6R7whhuRD4ax8IipLcLPlZGJKkBxgHp++U4N/vKyU16/YDQr2f5seajD3jIw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.12.9
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
   /@babel/plugin-syntax-jsx@7.14.5(@babel/core@7.20.2):
     resolution: {integrity: sha512-ohuFIsOMXJnbOMRfX7/w7LocdR6R7whhuRD4ax8IipLcLPlZGJKkBxgHp++U4N/vKyU16/YDQr2f5seajD3jIw==}
     engines: {node: '>=6.9.0'}
@@ -6293,6 +5938,15 @@ packages:
       '@babel/core': 7.20.2
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
+
+  /@babel/plugin-syntax-jsx@7.18.6:
+    resolution: {integrity: sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/helper-plugin-utils': 7.20.2
+    dev: false
 
   /@babel/plugin-syntax-jsx@7.18.6(@babel/core@7.20.2):
     resolution: {integrity: sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==}
@@ -7703,6 +7357,10 @@ packages:
       '@babel/helper-validator-identifier': 7.19.1
       to-fast-properties: 2.0.0
 
+  /@balena/dockerignore@1.0.2:
+    resolution: {integrity: sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==}
+    dev: false
+
   /@changesets/apply-release-plan@6.1.3:
     resolution: {integrity: sha512-ECDNeoc3nfeAe1jqJb5aFQX7CqzQhD2klXRez2JDb/aVpGUbX673HgKrnrgJRuQR/9f2TtLoYIzrGB9qwD77mg==}
     dependencies:
@@ -7917,7 +7575,7 @@ packages:
     resolution: {integrity: sha512-rODCdDtGyudLj+Va8b6w6Y85KE85bXRsps/R4Yjwt5vueXKXZQKYw0aA9knxLBT6a/bI/GMrAcmCR75KYOM6hg==}
     dev: false
 
-  /@docsearch/react@3.3.0(@algolia/client-search@4.14.2)(react-dom@17.0.2)(react@17.0.2):
+  /@docsearch/react@3.3.0(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-fhS5adZkae2SSdMYEMVg6pxI5a/cE+tW16ki1V0/ur4Fdok3hBRkmN/H8VvlXnxzggkQIIRIVvYPn00JPjen3A==}
     peerDependencies:
       '@types/react': '>= 16.8.0 < 19.0.0'
@@ -7932,7 +7590,7 @@ packages:
         optional: true
     dependencies:
       '@algolia/autocomplete-core': 1.7.2
-      '@algolia/autocomplete-preset-algolia': 1.7.2(@algolia/client-search@4.14.2)(algoliasearch@4.14.2)
+      '@algolia/autocomplete-preset-algolia': 1.7.2(algoliasearch@4.14.2)
       '@docsearch/css': 3.3.0
       algoliasearch: 4.14.2
       react: 17.0.2
@@ -8018,7 +7676,7 @@ packages:
       tslib: 2.4.1
       update-notifier: 5.1.0
       url-loader: 4.1.1(file-loader@6.2.0)(webpack@5.75.0)
-      wait-on: 6.0.1(debug@4.3.4)
+      wait-on: 6.0.1
       webpack: 5.75.0
       webpack-bundle-analyzer: 4.7.0
       webpack-dev-server: 4.11.1(webpack@5.75.0)
@@ -8267,7 +7925,7 @@ packages:
       fs-extra: 10.1.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
-      react-json-view: 1.21.3(@types/react@17.0.52)(react-dom@17.0.2)(react@17.0.2)
+      react-json-view: 1.21.3(react-dom@17.0.2)(react@17.0.2)
       tslib: 2.5.0
     transitivePeerDependencies:
       - '@parcel/css'
@@ -8375,7 +8033,7 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/preset-classic@2.0.0-beta.18(@algolia/client-search@4.14.2)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5):
+  /@docusaurus/preset-classic@2.0.0-beta.18(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5):
     resolution: {integrity: sha512-TfDulvFt/vLWr/Yy7O0yXgwHtJhdkZ739bTlFNwEkRMAy8ggi650e52I1I0T79s67llecb4JihgHPW+mwiVkCQ==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -8392,7 +8050,7 @@ packages:
       '@docusaurus/plugin-sitemap': 2.0.0-beta.18(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5)
       '@docusaurus/theme-classic': 2.0.0-beta.18(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5)
       '@docusaurus/theme-common': 2.0.0-beta.18(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5)
-      '@docusaurus/theme-search-algolia': 2.0.0-beta.18(@algolia/client-search@4.14.2)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5)
+      '@docusaurus/theme-search-algolia': 2.0.0-beta.18(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5)
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
     transitivePeerDependencies:
@@ -8502,14 +8160,14 @@ packages:
       - webpack-cli
     dev: false
 
-  /@docusaurus/theme-search-algolia@2.0.0-beta.18(@algolia/client-search@4.14.2)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5):
+  /@docusaurus/theme-search-algolia@2.0.0-beta.18(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5):
     resolution: {integrity: sha512-2w97KO/gnjI49WVtYQqENpQ8iO1Sem0yaTxw7/qv/ndlmIAQD0syU4yx6GsA7bTQCOGwKOWWzZSetCgUmTnWgA==}
     engines: {node: '>=14'}
     peerDependencies:
       react: ^16.8.4 || ^17.0.0
       react-dom: ^16.8.4 || ^17.0.0
     dependencies:
-      '@docsearch/react': 3.3.0(@algolia/client-search@4.14.2)(react-dom@17.0.2)(react@17.0.2)
+      '@docsearch/react': 3.3.0(react-dom@17.0.2)(react@17.0.2)
       '@docusaurus/core': 2.0.0-beta.18(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5)
       '@docusaurus/logger': 2.0.0-beta.18
       '@docusaurus/plugin-content-docs': 2.0.0-beta.18(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5)
@@ -8635,14 +8293,13 @@ packages:
     resolution: {integrity: sha512-8HqW8EVqjnCmWXVpqAOZf+EGESdkR27odcMMMGefgKXtar00SoYNSryGv//TELI4T3QFsECo78p+0lmalk/CFA==}
     dev: true
 
-  /@emotion/babel-plugin@11.10.5(@babel/core@7.21.3):
+  /@emotion/babel-plugin@11.10.5:
     resolution: {integrity: sha512-xE7/hyLHJac7D2Ve9dKroBBZqBT7WuPQmWcq7HSGb84sUuP4mlOWoB8dvVfD9yk5DHkU1m6RW7xSoDtnQHNQeA==}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.21.3
       '@babel/helper-module-imports': 7.18.6
-      '@babel/plugin-syntax-jsx': 7.18.6(@babel/core@7.21.3)
+      '@babel/plugin-syntax-jsx': 7.18.6
       '@babel/runtime': 7.21.0
       '@emotion/hash': 0.9.0
       '@emotion/memoize': 0.8.0
@@ -8673,7 +8330,7 @@ packages:
     resolution: {integrity: sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA==}
     dev: false
 
-  /@emotion/react@11.10.5(@babel/core@7.21.3)(@types/react@17.0.52)(react@17.0.2):
+  /@emotion/react@11.10.5(@types/react@17.0.52)(react@17.0.2):
     resolution: {integrity: sha512-TZs6235tCJ/7iF6/rvTaOH4oxQg2gMAcdHemjwLKIjKz4rRuYe1HJ2TQJKnAcRAfOUDdU8XoDadCe1rl72iv8A==}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -8685,9 +8342,8 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/core': 7.21.3
       '@babel/runtime': 7.21.0
-      '@emotion/babel-plugin': 11.10.5(@babel/core@7.21.3)
+      '@emotion/babel-plugin': 11.10.5
       '@emotion/cache': 11.10.5
       '@emotion/serialize': 1.1.1
       '@emotion/use-insertion-effect-with-fallbacks': 1.0.0(react@17.0.2)
@@ -10313,23 +9969,6 @@ packages:
       webpack-sources: 3.2.3
     dev: false
 
-  /@sls-next/aws-common@3.7.0(@aws-sdk/signature-v4-crt@3.292.0)(@babel/core@7.12.9)(typescript@4.9.5):
-    resolution: {integrity: sha512-NNaJkBg+iJBlZW3pj4we3P6dzuLEMloWSnwzNXU518KGWvx7r3+2pD0kMe+LprTRBuOP82DCeYMHxncM3CvC+w==}
-    dependencies:
-      '@aws-sdk/client-s3': 3.54.0(@aws-sdk/signature-v4-crt@3.292.0)
-      '@aws-sdk/client-sqs': 3.54.0
-      '@sls-next/core': 3.7.0(@babel/core@7.12.9)(typescript@4.9.5)
-    transitivePeerDependencies:
-      - '@aws-sdk/signature-v4-crt'
-      - '@babel/core'
-      - fibers
-      - node-sass
-      - sass
-      - supports-color
-      - typescript
-      - webpack
-    dev: true
-
   /@sls-next/aws-common@3.7.0(@aws-sdk/signature-v4-crt@3.292.0)(@babel/core@7.20.2)(typescript@4.9.5):
     resolution: {integrity: sha512-NNaJkBg+iJBlZW3pj4we3P6dzuLEMloWSnwzNXU518KGWvx7r3+2pD0kMe+LprTRBuOP82DCeYMHxncM3CvC+w==}
     dependencies:
@@ -10338,35 +9977,6 @@ packages:
       '@sls-next/core': 3.7.0(@babel/core@7.20.2)(typescript@4.9.5)
     transitivePeerDependencies:
       - '@aws-sdk/signature-v4-crt'
-      - '@babel/core'
-      - fibers
-      - node-sass
-      - sass
-      - supports-color
-      - typescript
-      - webpack
-    dev: true
-
-  /@sls-next/core@3.7.0(@babel/core@7.12.9)(typescript@4.9.5):
-    resolution: {integrity: sha512-fCRV0iI84FboRk8YKATSFVp4dzR27zd6Rez/qfa4Utv9HL9UZbDTpKlyuUp24vEvADAZSp5laxj1JgOZBn2iOQ==}
-    dependencies:
-      '@hapi/accept': 5.0.2
-      cookie: 0.4.2
-      execa: 5.1.1
-      fast-glob: 3.2.11
-      fresh: 0.5.2
-      fs-extra: 9.1.0
-      is-animated: 2.0.2
-      jsonwebtoken: 8.5.1
-      next: 11.1.2(@babel/core@7.12.9)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5)
-      node-fetch: 2.6.5
-      normalize-path: 3.0.0
-      path-to-regexp: 6.2.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-      send: 0.17.2
-      sharp: 0.29.1
-    transitivePeerDependencies:
       - '@babel/core'
       - fibers
       - node-sass
@@ -10405,35 +10015,6 @@ packages:
       - webpack
     dev: true
 
-  /@sls-next/lambda-at-edge@3.7.0(@aws-sdk/signature-v4-crt@3.292.0)(@babel/core@7.12.9)(builtin-modules@3.2.0)(typescript@4.9.5):
-    resolution: {integrity: sha512-7eTqq1baZEuvEhexDchsP3QdOqPYaW123c7TupYB60Rs31KQ12xXvpzgn+mTMuFVIOQUDY5y8EKsuzYGRrQfcw==}
-    hasBin: true
-    peerDependencies:
-      builtin-modules: 3.2.0
-    dependencies:
-      '@aws-sdk/client-s3': 3.54.0(@aws-sdk/signature-v4-crt@3.292.0)
-      '@aws-sdk/client-sqs': 3.54.0
-      '@sls-next/aws-common': 3.7.0(@aws-sdk/signature-v4-crt@3.292.0)(@babel/core@7.12.9)(typescript@4.9.5)
-      '@sls-next/core': 3.7.0(@babel/core@7.12.9)(typescript@4.9.5)
-      '@vercel/nft': 0.17.5
-      builtin-modules: 3.2.0
-      execa: 5.1.1
-      fs-extra: 9.1.0
-      get-stream: 6.0.1
-      node-fetch: 2.6.5
-      normalize-path: 3.0.0
-    transitivePeerDependencies:
-      - '@aws-sdk/signature-v4-crt'
-      - '@babel/core'
-      - encoding
-      - fibers
-      - node-sass
-      - sass
-      - supports-color
-      - typescript
-      - webpack
-    dev: true
-
   /@sls-next/lambda-at-edge@3.7.0(@aws-sdk/signature-v4-crt@3.292.0)(@babel/core@7.20.2)(builtin-modules@3.2.0)(typescript@4.9.5):
     resolution: {integrity: sha512-7eTqq1baZEuvEhexDchsP3QdOqPYaW123c7TupYB60Rs31KQ12xXvpzgn+mTMuFVIOQUDY5y8EKsuzYGRrQfcw==}
     hasBin: true
@@ -10463,22 +10044,6 @@ packages:
       - webpack
     dev: true
 
-  /@solidjs/meta@0.28.5(solid-js@1.7.5):
-    resolution: {integrity: sha512-52luJR6hVNMA1K8Od5OD0d8WVz/svqZG4is8lrDimiUGxdia3DzuLF+pK56dnEzbNt9cA42qVFL134U9LkC9Gg==}
-    peerDependencies:
-      solid-js: '>=1.4.0'
-    dependencies:
-      solid-js: 1.7.5
-    dev: true
-
-  /@solidjs/router@0.6.0(solid-js@1.7.5):
-    resolution: {integrity: sha512-7ug2fzXXhvvDBL4CQyMvMM9o3dgBE6PoRh38T8UTmMnYz4rcCfROqSZc9yq+YEC96qWt5OvJgZ1Uj/4EAQXlfA==}
-    peerDependencies:
-      solid-js: ^1.5.3
-    dependencies:
-      solid-js: 1.7.5
-    dev: true
-
   /@stitches/react@1.2.8(react@17.0.2):
     resolution: {integrity: sha512-9g9dWI4gsSVe8bNLlb+lMkBYsnIKCZTmvqvDG+Avnn69XfmHZKiaMrx7cgTaddq7aTPPmXiTsbFcUy0xgI4+wA==}
     peerDependencies:
@@ -10487,7 +10052,7 @@ packages:
       react: 17.0.2
     dev: false
 
-  /@sveltejs/kit@1.16.2(svelte@3.59.1)(vite@4.1.4):
+  /@sveltejs/kit@1.16.2:
     resolution: {integrity: sha512-yxcpA4nvlVlJ+VyYnj0zD3QN05kfmoh4OyitlPrVG34nnZSHzFpE4eZ33X1A/tc9prslSFRhpM6rWngCs0nM8w==}
     engines: {node: ^16.14 || >=18}
     hasBin: true
@@ -10496,7 +10061,7 @@ packages:
       svelte: ^3.54.0
       vite: ^4.0.0
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 2.2.0(svelte@3.59.1)(vite@4.1.4)
+      '@sveltejs/vite-plugin-svelte': 2.2.0
       '@types/cookie': 0.5.1
       cookie: 0.5.0
       devalue: 4.3.0
@@ -10507,15 +10072,13 @@ packages:
       sade: 1.8.1
       set-cookie-parser: 2.6.0
       sirv: 2.0.2
-      svelte: 3.59.1
       tiny-glob: 0.2.9
       undici: 5.22.0
-      vite: 4.1.4(@types/node@18.15.3)
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@sveltejs/vite-plugin-svelte@2.2.0(svelte@3.59.1)(vite@4.1.4):
+  /@sveltejs/vite-plugin-svelte@2.2.0:
     resolution: {integrity: sha512-KDtdva+FZrZlyug15KlbXuubntAPKcBau0K7QhAIqC5SAy0uDbjZwoexDRx0L0J2T4niEfC6FnA9GuQQJKg+Aw==}
     engines: {node: ^14.18.0 || >= 16}
     peerDependencies:
@@ -10526,10 +10089,8 @@ packages:
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.0
-      svelte: 3.59.1
-      svelte-hmr: 0.15.1(svelte@3.59.1)
-      vite: 4.1.4(@types/node@18.15.3)
-      vitefu: 0.2.4(vite@4.1.4)
+      svelte-hmr: 0.15.1
+      vitefu: 0.2.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -10694,16 +10255,15 @@ packages:
       defer-to-connect: 1.1.3
     dev: false
 
-  /@trpc/client@9.18.0(@trpc/server@9.18.0):
+  /@trpc/client@9.18.0:
     resolution: {integrity: sha512-kqC0/nuA+/wVvddaFbSRMbSZ3oGAY4nl2pHVxM7jqDBLkn6nbk0IHK0oJ0g1tDZxyfg4xuZtTrzh0yYpE4C69w==}
     peerDependencies:
       '@trpc/server': 9.18.0
     dependencies:
       '@babel/runtime': 7.20.1
-      '@trpc/server': 9.18.0
     dev: false
 
-  /@trpc/react@9.18.0(@trpc/client@9.18.0)(@trpc/server@9.18.0)(react-dom@17.0.2)(react-query@3.39.2)(react@17.0.2):
+  /@trpc/react@9.18.0(@trpc/client@9.18.0)(react-dom@17.0.2)(react-query@3.39.2)(react@17.0.2):
     resolution: {integrity: sha512-stoHIA/9OJtVnmnR/JtVLs52A3gKfTUjvoID8lQTL3LHJbDOzDxKnefUdMr8RfgeC92ALeIbdzeO08P1/0THjQ==}
     peerDependencies:
       '@trpc/client': 9.18.0
@@ -10713,8 +10273,7 @@ packages:
       react-query: ^3.31.0 || ^4.0.0-alpha.4
     dependencies:
       '@babel/runtime': 7.20.1
-      '@trpc/client': 9.18.0(@trpc/server@9.18.0)
-      '@trpc/server': 9.18.0
+      '@trpc/client': 9.18.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
       react-query: 3.39.2(react-dom@17.0.2)(react@17.0.2)
@@ -10722,12 +10281,6 @@ packages:
 
   /@trpc/server@9.16.0:
     resolution: {integrity: sha512-IENsJs41ZR4oeFUJhsNNTSgEOtuRN0m9u7ec4u3eG/qOc7bIoo1nDoYtx4bl6OJJSQYEytG9tlcVz9G8OAaHbg==}
-    dependencies:
-      tslib: 2.5.0
-    dev: false
-
-  /@trpc/server@9.18.0:
-    resolution: {integrity: sha512-xWBC2+Q5OuJfK4kN9LqvpnncOP3T2I1duc5xDAnYOhhmvnKrfoUQoBReSqA5MohomAB/EDcRVCea2sKoNIoa0g==}
     dependencies:
       tslib: 2.5.0
     dev: false
@@ -10988,10 +10541,6 @@ packages:
   /@types/node@12.20.55:
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
     dev: true
-
-  /@types/node@14.18.46:
-    resolution: {integrity: sha512-n4yVT5FuY5NCcGHCosQSGvvCT74HhowymPN2OEcsHPw6U1NuxV9dvxWbrM2dnBukWjdMYzig1WfIkWdTTQJqng==}
-    dev: false
 
   /@types/node@17.0.45:
     resolution: {integrity: sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==}
@@ -11465,7 +11014,7 @@ packages:
   /adm-zip@0.5.10:
     resolution: {integrity: sha512-x0HvcHqVJNTPk/Bw8JbLWlWoo6Wwnsug0fnYYro1HBrjxZ3G7/AZk7Ahv8JwDe1uIcz8eBqvu86FuF1POiG7vQ==}
     engines: {node: '>=6.0'}
-    dev: true
+    dev: false
 
   /agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
@@ -11484,10 +11033,8 @@ packages:
       indent-string: 4.0.0
     dev: false
 
-  /ajv-formats@2.1.1(ajv@8.11.0):
+  /ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
-    peerDependencies:
-      ajv: ^8.0.0
     peerDependenciesMeta:
       ajv:
         optional: true
@@ -11875,7 +11422,7 @@ packages:
       typescript: 4.9.5
       unist-util-visit: 4.1.2
       vfile: 5.3.7
-      vite: 4.1.4(@types/node@18.15.3)
+      vite: 4.1.4
       vitefu: 0.2.4(vite@4.1.4)
       yargs-parser: 21.1.1
       zod: 3.21.4
@@ -11891,10 +11438,6 @@ packages:
 
   /async-limiter@1.0.1:
     resolution: {integrity: sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==}
-    dev: false
-
-  /async@1.5.2:
-    resolution: {integrity: sha512-nSVgobk4rv61R9PUSDtYt7mPVB2olxNR5RWJcAsH676/ef11bUZwvu7+RGYrYauVdDPcO519v68wRhXQtxsV9w==}
     dev: false
 
   /async@3.2.4:
@@ -11950,28 +11493,6 @@ packages:
     resolution: {integrity: sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==}
     engines: {node: '>= 0.4'}
 
-  /aws-cdk-lib@2.62.2(constructs@10.1.156):
-    resolution: {integrity: sha512-ynyoEFQckICFJzbUd89pWjol3GGbxRF05E8BCPEyy++vLHJZdqaJxRL4REl4lrdznnkb1kvxtBSGg4cOkR4o3w==}
-    engines: {node: '>= 14.15.0'}
-    peerDependencies:
-      constructs: ^10.0.0
-    dependencies:
-      '@aws-cdk/asset-awscli-v1': 2.2.131
-      '@aws-cdk/asset-kubectl-v20': 2.1.1
-      '@aws-cdk/asset-node-proxy-agent-v5': 2.0.107
-      constructs: 10.1.156
-    dev: false
-    bundledDependencies:
-      - '@balena/dockerignore'
-      - case
-      - fs-extra
-      - ignore
-      - jsonschema
-      - minimatch
-      - punycode
-      - semver
-      - yaml
-
   /aws-cdk-lib@2.72.1(constructs@10.1.156):
     resolution: {integrity: sha512-uZJTXkZFFYoJsfzrvTMVCJH5x64DVw/7PiMHahCOIguipUFMzQI5sb3jmNkO7vgZIX/obQkuUl7C33rB/xfpcQ==}
     engines: {node: '>= 14.15.0'}
@@ -11981,7 +11502,17 @@ packages:
       '@aws-cdk/asset-awscli-v1': 2.2.131
       '@aws-cdk/asset-kubectl-v20': 2.1.1
       '@aws-cdk/asset-node-proxy-agent-v5': 2.0.107
+      '@balena/dockerignore': 1.0.2
+      case: 1.6.3
       constructs: 10.1.156
+      fs-extra: 9.1.0
+      ignore: 5.2.4
+      jsonschema: 1.4.1
+      minimatch: 3.1.2
+      punycode: 2.3.0
+      semver: 7.3.8
+      table: 6.8.1
+      yaml: 1.10.2
     dev: false
     bundledDependencies:
       - '@balena/dockerignore'
@@ -12068,9 +11599,17 @@ packages:
   /axios@0.24.0:
     resolution: {integrity: sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==}
     dependencies:
-      follow-redirects: 1.15.2(debug@4.3.4)
+      follow-redirects: 1.15.2
     transitivePeerDependencies:
       - debug
+
+  /axios@0.25.0:
+    resolution: {integrity: sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==}
+    dependencies:
+      follow-redirects: 1.15.2
+    transitivePeerDependencies:
+      - debug
+    dev: false
 
   /axios@0.25.0(debug@4.3.4):
     resolution: {integrity: sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==}
@@ -12078,6 +11617,7 @@ packages:
       follow-redirects: 1.15.2(debug@4.3.4)
     transitivePeerDependencies:
       - debug
+    dev: true
 
   /babel-loader@8.3.0(@babel/core@7.20.2)(webpack@5.75.0):
     resolution: {integrity: sha512-H8SvsMF+m9t15HNLMipppzkC+Y2Yq+v3SonZyU70RBL/h1gxPkH08Ot8pEE9Z4Kd+czyWJClmFS8qzIP9OZ04Q==}
@@ -12633,6 +12173,11 @@ packages:
   /caniuse-lite@1.0.30001466:
     resolution: {integrity: sha512-ewtFBSfWjEmxUgNBSZItFSmVtvk9zkwkl1OfRZlKA8slltRN+/C/tuGVrF9styXkN36Yu3+SeJ1qkXxDEyNZ5w==}
 
+  /case@1.6.3:
+    resolution: {integrity: sha512-mzDSXIPaFwVDvZAHqZ9VlbyF4yyXRuX6IvB06WvPYkqJVO24kX1PPhv9bfpKNFZyxYFmmgo03HUiD8iklmJYRQ==}
+    engines: {node: '>= 0.8.0'}
+    dev: false
+
   /ccount@1.1.0:
     resolution: {integrity: sha512-vlNK021QdI7PNeiUh/lKkC/mNHHfV0m/Ad5JoI0TYtlBnJAslM/JIkm/tGC88bkLIwO6OQ5uV6ztS6kVAtCDlg==}
     dev: false
@@ -12640,20 +12185,6 @@ packages:
   /ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
     dev: true
-
-  /cdk-assets@2.62.2:
-    resolution: {integrity: sha512-NbBLaHZ5NY+OSHBp+nQaEHIB+qsm3poySSpjnxsyWjX9OoaAMte5kknxpvu099NwFYWSk/DvWdNxec9UiA8JBw==}
-    engines: {node: '>= 14.15.0'}
-    hasBin: true
-    dependencies:
-      '@aws-cdk/cloud-assembly-schema': 2.62.2
-      '@aws-cdk/cx-api': 2.62.2(@aws-cdk/cloud-assembly-schema@2.62.2)
-      archiver: 5.3.1
-      aws-sdk: 2.1352.0
-      glob: 7.2.3
-      mime: 2.6.0
-      yargs: 16.2.0
-    dev: false
 
   /cdk-assets@2.72.1:
     resolution: {integrity: sha512-qxKgIBAdJhBJV23WAGLcQ4x89k/zmYhWeQeZW3TEbv//TZFIRWlgpkz6XnTzNIuluWghxMOvHym/LoRMpSaJcg==}
@@ -13135,7 +12666,7 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       ajv: 8.11.0
-      ajv-formats: 2.1.1(ajv@8.11.0)
+      ajv-formats: 2.1.1
       atomically: 1.7.0
       debounce-fn: 4.0.0
       dot-prop: 6.0.1
@@ -14572,7 +14103,7 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-plugin-solid@0.4.2(esbuild@0.14.54)(solid-js@1.7.5):
+  /esbuild-plugin-solid@0.4.2(esbuild@0.14.54):
     resolution: {integrity: sha512-T5GphLoud3RumjeNYO3K9WVjWDzVKG5evlS7hUEUI0n9tiCL+CnbvJh3SSwFi3xeeXpZRrnZc1gd6FWQsVobTg==}
     peerDependencies:
       esbuild: '>=0.12'
@@ -14582,7 +14113,6 @@ packages:
       '@babel/preset-typescript': 7.18.6(@babel/core@7.21.3)
       babel-preset-solid: 1.6.7(@babel/core@7.21.3)
       esbuild: 0.14.54
-      solid-js: 1.7.5
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -15244,6 +14774,15 @@ packages:
       - encoding
     dev: false
 
+  /follow-redirects@1.15.2:
+    resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
   /follow-redirects@1.15.2(debug@4.3.4):
     resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
     engines: {node: '>=4.0'}
@@ -15658,14 +15197,6 @@ packages:
   /grapheme-splitter@1.0.4:
     resolution: {integrity: sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==}
     dev: true
-
-  /graphql-helix@1.12.0(graphql@16.6.0):
-    resolution: {integrity: sha512-wTu1m/ZFBCgzLPCg/dHO4cNy9JR5Sq/3RqDVblqrU3b/Yem7EXZtQMzG045tHqkCdbgcgQl+kIkXDur1yLfdtw==}
-    peerDependencies:
-      graphql: ^15.3.0 || ^16.0.0
-    dependencies:
-      graphql: 16.6.0
-    dev: false
 
   /graphql-yoga@3.9.1(graphql@16.6.0):
     resolution: {integrity: sha512-BB6EkN64VBTXWmf9Kym2OsVZFzBC0mAsQNo9eNB5xIr3t+x7qepQ34xW5A353NWol3Js3xpzxwIKFVF6l9VsPg==}
@@ -16142,7 +15673,7 @@ packages:
     engines: {node: '>=8.0.0'}
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.2(debug@4.3.4)
+      follow-redirects: 1.15.2
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
@@ -16839,7 +16370,7 @@ packages:
     resolution: {integrity: sha512-wLe+lJHeG8Xt6uEubS4x0LVjS/3kXXu9dGoj9BNnlhYq7Kts0Pbb2pvv5KiI0yaKH/eaiR0LUOBhOVo9ktd05A==}
     dev: false
 
-  /jotai@1.9.2(@babel/core@7.21.3)(immer@9.0.16)(react@17.0.2):
+  /jotai@1.9.2(immer@9.0.16)(react@17.0.2):
     resolution: {integrity: sha512-/893WrniZwoVc0+3JR056r0FTC/tGbgyHco9dfgde6K8TU6XNxrOSw4jCRdDicncw67A37v2GNGzXSpHKbHPmw==}
     engines: {node: '>=12.7.0'}
     peerDependencies:
@@ -16870,7 +16401,6 @@ packages:
       xstate:
         optional: true
     dependencies:
-      '@babel/core': 7.21.3
       immer: 9.0.16
       react: 17.0.2
     dev: false
@@ -16988,12 +16518,6 @@ packages:
       semver: 5.7.1
     dev: true
 
-  /jszip@2.7.0:
-    resolution: {integrity: sha512-JIsRKRVC3gTRo2vM4Wy9WBC3TRcfnIZU8k65Phi3izkvPH975FowRYtKGT6PxevA0XnJ/yO8b0QwV0ydVyQwfw==}
-    dependencies:
-      pako: 1.0.11
-    dev: false
-
   /jwa@1.4.1:
     resolution: {integrity: sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==}
     dependencies:
@@ -17045,29 +16569,6 @@ packages:
 
   /kysely-codegen@0.10.0(kysely@0.23.5):
     resolution: {integrity: sha512-EV2v9yr9N9WrUPrURvFl5FPTtz39npsi1p1tLpJwEcFeOAKAPJruBpAASvnZWdqu5Pw/aaTssStE3qcI2sfxMQ==}
-    hasBin: true
-    peerDependencies:
-      better-sqlite3: '>=7.6.2'
-      kysely: '>=0.19.12'
-      mysql2: ^2.3.3
-      pg: ^8.8.0
-    peerDependenciesMeta:
-      better-sqlite3:
-        optional: true
-      mysql2:
-        optional: true
-      pg:
-        optional: true
-    dependencies:
-      chalk: 4.1.2
-      dotenv: 16.0.3
-      kysely: 0.23.5
-      micromatch: 4.0.5
-      minimist: 1.2.8
-    dev: false
-
-  /kysely-codegen@0.9.0(kysely@0.23.5):
-    resolution: {integrity: sha512-VCkrEY0WPwObvT4LGJkwLn29DXmvwG2oAv94qa+yAXDPAWtYTfO8NQSqyeEiNHEWmuKI+Sl+ANSn63by2Xn1tw==}
     hasBin: true
     peerDependencies:
       better-sqlite3: '>=7.6.2'
@@ -18265,88 +17766,6 @@ packages:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
     dev: false
 
-  /next@11.1.2(@babel/core@7.12.9)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5):
-    resolution: {integrity: sha512-azEYL0L+wFjv8lstLru3bgvrzPvK0P7/bz6B/4EJ9sYkXeW8r5Bjh78D/Ol7VOg0EIPz0CXoe72hzAlSAXo9hw==}
-    engines: {node: '>=12.0.0'}
-    hasBin: true
-    peerDependencies:
-      fibers: '>= 3.1.0'
-      node-sass: ^4.0.0 || ^5.0.0
-      react: ^17.0.2
-      react-dom: ^17.0.2
-      sass: ^1.3.0
-    peerDependenciesMeta:
-      fibers:
-        optional: true
-      node-sass:
-        optional: true
-      sass:
-        optional: true
-    dependencies:
-      '@babel/runtime': 7.15.3
-      '@hapi/accept': 5.0.2
-      '@next/env': 11.1.2
-      '@next/polyfill-module': 11.1.2
-      '@next/react-dev-overlay': 11.1.2(react-dom@17.0.2)(react@17.0.2)
-      '@next/react-refresh-utils': 11.1.2(react-refresh@0.8.3)
-      '@node-rs/helper': 1.2.1
-      assert: 2.0.0
-      ast-types: 0.13.2
-      browserify-zlib: 0.2.0
-      browserslist: 4.16.6
-      buffer: 5.6.0
-      caniuse-lite: 1.0.30001466
-      chalk: 2.4.2
-      chokidar: 3.5.1
-      constants-browserify: 1.0.0
-      crypto-browserify: 3.12.0
-      cssnano-simple: 3.0.0(postcss@8.2.15)
-      domain-browser: 4.19.0
-      encoding: 0.1.13
-      etag: 1.8.1
-      find-cache-dir: 3.3.1
-      get-orientation: 1.1.2
-      https-browserify: 1.0.0
-      image-size: 1.0.0
-      jest-worker: 27.0.0-next.5
-      native-url: 0.3.4
-      node-fetch: 2.6.1
-      node-html-parser: 1.4.9
-      node-libs-browser: 2.2.1
-      os-browserify: 0.3.0
-      p-limit: 3.1.0
-      path-browserify: 1.0.1
-      pnp-webpack-plugin: 1.6.4(typescript@4.9.5)
-      postcss: 8.2.15
-      process: 0.11.10
-      querystring-es3: 0.2.1
-      raw-body: 2.4.1
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-      react-is: 17.0.2
-      react-refresh: 0.8.3
-      stream-browserify: 3.0.0
-      stream-http: 3.1.1
-      string_decoder: 1.3.0
-      styled-jsx: 4.0.1(@babel/core@7.12.9)(react@17.0.2)
-      timers-browserify: 2.0.12
-      tty-browserify: 0.0.1
-      use-subscription: 1.5.1(react@17.0.2)
-      util: 0.12.4
-      vm-browserify: 1.1.2
-      watchpack: 2.1.1
-    optionalDependencies:
-      '@next/swc-darwin-arm64': 11.1.2
-      '@next/swc-darwin-x64': 11.1.2
-      '@next/swc-linux-x64-gnu': 11.1.2
-      '@next/swc-win32-x64-msvc': 11.1.2
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
-      - typescript
-      - webpack
-    dev: true
-
   /next@11.1.2(@babel/core@7.20.2)(react-dom@17.0.2)(react@17.0.2)(typescript@4.9.5):
     resolution: {integrity: sha512-azEYL0L+wFjv8lstLru3bgvrzPvK0P7/bz6B/4EJ9sYkXeW8r5Bjh78D/Ol7VOg0EIPz0CXoe72hzAlSAXo9hw==}
     engines: {node: '>=12.0.0'}
@@ -18968,6 +18387,7 @@ packages:
 
   /pako@1.0.11:
     resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+    dev: true
 
   /param-case@3.0.4:
     resolution: {integrity: sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==}
@@ -20137,11 +19557,6 @@ packages:
     engines: {node: '>=6.0.0'}
     dev: false
 
-  /q@1.5.1:
-    resolution: {integrity: sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==}
-    engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
-    dev: false
-
   /qs@6.11.0:
     resolution: {integrity: sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==}
     engines: {node: '>=0.6'}
@@ -20374,6 +19789,23 @@ packages:
       - encoding
     dev: false
 
+  /react-json-view@1.21.3(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-13p8IREj9/x/Ye4WI/JpjhoIwuzEgUAtgJZNBJckfzJt1qyh24BdTm6UQNGnyTq9dapQdrqvquZTo3dz1X6Cjw==}
+    peerDependencies:
+      react: ^17.0.0 || ^16.3.0 || ^15.5.4
+      react-dom: ^17.0.0 || ^16.3.0 || ^15.5.4
+    dependencies:
+      flux: 4.0.3(react@17.0.2)
+      react: 17.0.2
+      react-base16-styling: 0.6.0
+      react-dom: 17.0.2(react@17.0.2)
+      react-lifecycles-compat: 3.0.4
+      react-textarea-autosize: 8.4.0(react@17.0.2)
+    transitivePeerDependencies:
+      - '@types/react'
+      - encoding
+    dev: false
+
   /react-lifecycles-compat@3.0.4:
     resolution: {integrity: sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==}
     dev: false
@@ -20553,13 +19985,13 @@ packages:
       react: 17.0.2
     dev: false
 
-  /react-spinners@0.11.0(@babel/core@7.21.3)(@types/react@17.0.52)(react-dom@17.0.2)(react@17.0.2):
+  /react-spinners@0.11.0(@types/react@17.0.52)(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-rDZc0ABWn/M1OryboGsWVmIPg8uYWl0L35jPUhr40+Yg+syVPjeHwvnB7XWaRpaKus3M0cG9BiJA+ZB0dAwWyw==}
     peerDependencies:
       react: ^16.0.0 || ^17.0.0
       react-dom: ^16.0.0 || ^17.0.0
     dependencies:
-      '@emotion/react': 11.10.5(@babel/core@7.21.3)(@types/react@17.0.52)(react@17.0.2)
+      '@emotion/react': 11.10.5(@types/react@17.0.52)(react@17.0.2)
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
     transitivePeerDependencies:
@@ -20594,6 +20026,20 @@ packages:
       react: 17.0.2
       use-composed-ref: 1.3.0(react@17.0.2)
       use-latest: 1.2.1(@types/react@17.0.52)(react@17.0.2)
+    transitivePeerDependencies:
+      - '@types/react'
+    dev: false
+
+  /react-textarea-autosize@8.4.0(react@17.0.2):
+    resolution: {integrity: sha512-YrTFaEHLgJsi8sJVYHBzYn+mkP3prGkmP2DKb/tm0t7CLJY5t1Rxix8070LAKb0wby7bl/lf2EeHkuMihMZMwQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.21.0
+      react: 17.0.2
+      use-composed-ref: 1.3.0(react@17.0.2)
+      use-latest: 1.2.1(react@17.0.2)
     transitivePeerDependencies:
       - '@types/react'
     dev: false
@@ -21304,7 +20750,7 @@ packages:
     dependencies:
       '@types/json-schema': 7.0.11
       ajv: 8.11.0
-      ajv-formats: 2.1.1(ajv@8.11.0)
+      ajv-formats: 2.1.1
       ajv-keywords: 5.1.0(ajv@8.11.0)
     dev: false
 
@@ -21395,11 +20841,6 @@ packages:
     dependencies:
       randombytes: 2.1.0
     dev: false
-
-  /seroval@0.5.1:
-    resolution: {integrity: sha512-ZfhQVB59hmIauJG5Ydynupy8KHyr5imGNtdDhbZG68Ufh1Ynkv9KOYOAABf71oVbQxJ8VkWnMHAjEHE7fWkH5g==}
-    engines: {node: '>=10'}
-    dev: true
 
   /serve-handler@6.1.5:
     resolution: {integrity: sha512-ijPFle6Hwe8zfmBxJdE+5fta53fdIY0lHISJvuikXB3VYFafRjMRpOffSPvCYsbKyBA7pvy9oYr/BT1O3EArlg==}
@@ -21661,14 +21102,7 @@ packages:
       websocket-driver: 0.7.4
     dev: false
 
-  /solid-js@1.7.5:
-    resolution: {integrity: sha512-GfJ8na1e9FG1oAF5xC24BM+ATLym0sfH+ZblkbBFpueYdq3fWAoA5Ve+jGeIeLI7jmMGfa0rUaKruszNm2sH8w==}
-    dependencies:
-      csstype: 3.1.1
-      seroval: 0.5.1
-    dev: true
-
-  /solid-refresh@0.4.2(solid-js@1.7.5):
+  /solid-refresh@0.4.2:
     resolution: {integrity: sha512-6g1HsgQkY0X0ZmsaydNgHwRaQIhH3bAbagZiYwWnGO7mqli50ehlwQUN18RZ2MH3fTIs9Y1bankZapVhMVuijg==}
     peerDependencies:
       solid-js: ^1.3
@@ -21676,10 +21110,9 @@ packages:
       '@babel/generator': 7.21.3
       '@babel/helper-module-imports': 7.18.6
       '@babel/types': 7.21.4
-      solid-js: 1.7.5
     dev: true
 
-  /solid-start@0.2.11(@solidjs/meta@0.28.5)(@solidjs/router@0.6.0)(solid-js@1.7.5)(vite@3.2.5):
+  /solid-start@0.2.11(vite@3.2.5):
     resolution: {integrity: sha512-CwhzRTmvCrhUFFz4Bw3XTry2Hxnh/t9hqv1URmvlH3zTuDoJuSW9Sn08bbUdu/peOVF46tX3mTFn/pkfnljTfQ==}
     hasBin: true
     peerDependencies:
@@ -21694,8 +21127,6 @@ packages:
       '@babel/preset-env': 7.20.2(@babel/core@7.21.3)
       '@babel/preset-typescript': 7.18.6(@babel/core@7.21.3)
       '@babel/template': 7.20.7
-      '@solidjs/meta': 0.28.5(solid-js@1.7.5)
-      '@solidjs/router': 0.6.0(solid-js@1.7.5)
       '@types/cookie': 0.5.1
       '@vinxi/vite-plugin-inspect': 0.6.27(rollup@2.79.1)(vite@3.2.5)
       chokidar: 3.5.3
@@ -21706,7 +21137,7 @@ packages:
       dotenv: 16.0.3
       es-module-lexer: 1.2.0
       esbuild: 0.14.54
-      esbuild-plugin-solid: 0.4.2(esbuild@0.14.54)(solid-js@1.7.5)
+      esbuild-plugin-solid: 0.4.2(esbuild@0.14.54)
       fast-glob: 3.2.12
       get-port: 6.1.2
       parse-multipart-data: 1.5.0
@@ -21716,12 +21147,11 @@ packages:
       rollup-route-manifest: 1.0.0(rollup@2.79.1)
       sade: 1.8.1
       sirv: 2.0.2
-      solid-js: 1.7.5
       terser: 5.15.1
       undici: 5.22.0
       vite: 3.2.5(terser@5.15.1)
       vite-plugin-inspect: 0.6.1(vite@3.2.5)
-      vite-plugin-solid: 2.5.0(solid-js@1.7.5)(vite@3.2.5)
+      vite-plugin-solid: 2.5.0(vite@3.2.5)
       wait-on: 6.0.1(debug@4.3.4)
     transitivePeerDependencies:
       - supports-color
@@ -21745,6 +21175,7 @@ packages:
   /source-map@0.5.7:
     resolution: {integrity: sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==}
     engines: {node: '>=0.10.0'}
+    dev: false
 
   /source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
@@ -22108,28 +21539,6 @@ packages:
       inline-style-parser: 0.1.1
     dev: false
 
-  /styled-jsx@4.0.1(@babel/core@7.12.9)(react@17.0.2):
-    resolution: {integrity: sha512-Gcb49/dRB1k8B4hdK8vhW27Rlb2zujCk1fISrizCcToIs+55B4vmUM0N9Gi4nnVfFZWe55jRdWpAqH1ldAKWvQ==}
-    engines: {node: '>= 12.0.0'}
-    peerDependencies:
-      '@babel/core': '*'
-      react: '>= 16.8.0 || 17.x.x || 18.x.x'
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-    dependencies:
-      '@babel/core': 7.12.9
-      '@babel/plugin-syntax-jsx': 7.14.5(@babel/core@7.12.9)
-      '@babel/types': 7.15.0
-      convert-source-map: 1.7.0
-      loader-utils: 1.2.3
-      react: 17.0.2
-      source-map: 0.7.3
-      string-hash: 1.1.3
-      stylis: 3.5.4
-      stylis-rule-sheet: 0.0.10(stylis@3.5.4)
-    dev: true
-
   /styled-jsx@4.0.1(@babel/core@7.20.2)(react@17.0.2):
     resolution: {integrity: sha512-Gcb49/dRB1k8B4hdK8vhW27Rlb2zujCk1fISrizCcToIs+55B4vmUM0N9Gi4nnVfFZWe55jRdWpAqH1ldAKWvQ==}
     engines: {node: '>= 12.0.0'}
@@ -22224,18 +21633,11 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
-  /svelte-hmr@0.15.1(svelte@3.59.1):
+  /svelte-hmr@0.15.1:
     resolution: {integrity: sha512-BiKB4RZ8YSwRKCNVdNxK/GfY+r4Kjgp9jCLEy0DuqAKfmQtpL38cQK3afdpjw4sqSs4PLi3jIPJIFp259NkZtA==}
     engines: {node: ^12.20 || ^14.13.1 || >= 16}
     peerDependencies:
       svelte: '>=3.19.0'
-    dependencies:
-      svelte: 3.59.1
-    dev: true
-
-  /svelte@3.59.1:
-    resolution: {integrity: sha512-pKj8fEBmqf6mq3/NfrB9SLtcJcUvjYSWyePlfCqN9gujLB25RitWK8PvFzlwim6hD/We35KbPlRteuA6rnPGcQ==}
-    engines: {node: '>= 8'}
     dev: true
 
   /svg-parser@2.0.4:
@@ -23104,6 +22506,18 @@ packages:
       react: 17.0.2
     dev: false
 
+  /use-isomorphic-layout-effect@1.1.2(react@17.0.2):
+    resolution: {integrity: sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      react: 17.0.2
+    dev: false
+
   /use-latest@1.2.1(@types/react@17.0.52)(react@17.0.2):
     resolution: {integrity: sha512-xA+AVm/Wlg3e2P/JiItTziwS7FK92LWrDB0p+hgXloIMuVCeJJ8v6f0eeHyPZaJrM+usM1FkFfbNCrJGs8A/zw==}
     peerDependencies:
@@ -23116,6 +22530,19 @@ packages:
       '@types/react': 17.0.52
       react: 17.0.2
       use-isomorphic-layout-effect: 1.1.2(@types/react@17.0.52)(react@17.0.2)
+    dev: false
+
+  /use-latest@1.2.1(react@17.0.2):
+    resolution: {integrity: sha512-xA+AVm/Wlg3e2P/JiItTziwS7FK92LWrDB0p+hgXloIMuVCeJJ8v6f0eeHyPZaJrM+usM1FkFfbNCrJGs8A/zw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      react: 17.0.2
+      use-isomorphic-layout-effect: 1.1.2(react@17.0.2)
     dev: false
 
   /use-sidecar@1.1.2(@types/react@17.0.52)(react@17.0.2):
@@ -23351,7 +22778,7 @@ packages:
       - supports-color
     dev: true
 
-  /vite-plugin-solid@2.5.0(solid-js@1.7.5)(vite@3.2.5):
+  /vite-plugin-solid@2.5.0(vite@3.2.5):
     resolution: {integrity: sha512-VneGd3RyFJvwaiffsqgymeMaofn0IzQLPwDzafTV2f1agoWeeJlk5VrI5WqT9BTtLe69vNNbCJWqLhHr9fOdDw==}
     peerDependencies:
       solid-js: ^1.3.17 || ^1.4.0 || ^1.5.0 || ^1.6.0
@@ -23361,8 +22788,7 @@ packages:
       '@babel/preset-typescript': 7.18.6(@babel/core@7.21.3)
       babel-preset-solid: 1.6.7(@babel/core@7.21.3)
       merge-anything: 5.1.4
-      solid-js: 1.7.5
-      solid-refresh: 0.4.2(solid-js@1.7.5)
+      solid-refresh: 0.4.2
       vite: 3.2.5(terser@5.15.1)
       vitefu: 0.2.4(vite@3.2.5)
     transitivePeerDependencies:
@@ -23461,6 +22887,39 @@ packages:
       fsevents: 2.3.2
     dev: true
 
+  /vite@4.1.4:
+    resolution: {integrity: sha512-3knk/HsbSTKEin43zHu7jTwYWv81f8kgAL99G5NWBcA1LKvtvcVAC4JjBH1arBunO9kQka+1oGbrMKOjk4ZrBg==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': '>= 14'
+      less: '*'
+      sass: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      esbuild: 0.16.17
+      postcss: 8.4.21
+      resolve: 1.22.1
+      rollup: 3.19.1
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: true
+
   /vite@4.1.4(@types/node@18.15.3):
     resolution: {integrity: sha512-3knk/HsbSTKEin43zHu7jTwYWv81f8kgAL99G5NWBcA1LKvtvcVAC4JjBH1arBunO9kQka+1oGbrMKOjk4ZrBg==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -23495,6 +22954,15 @@ packages:
       fsevents: 2.3.2
     dev: true
 
+  /vitefu@0.2.4:
+    resolution: {integrity: sha512-fanAXjSaf9xXtOOeno8wZXIhgia+CZury481LsDaV++lSvcU2R9Ch2bPh3PYFyoHW+w9LqAeYRISVQjUIew14g==}
+    peerDependencies:
+      vite: ^3.0.0 || ^4.0.0
+    peerDependenciesMeta:
+      vite:
+        optional: true
+    dev: true
+
   /vitefu@0.2.4(vite@3.2.5):
     resolution: {integrity: sha512-fanAXjSaf9xXtOOeno8wZXIhgia+CZury481LsDaV++lSvcU2R9Ch2bPh3PYFyoHW+w9LqAeYRISVQjUIew14g==}
     peerDependencies:
@@ -23514,7 +22982,7 @@ packages:
       vite:
         optional: true
     dependencies:
-      vite: 4.1.4(@types/node@18.15.3)
+      vite: 4.1.4
     dev: true
 
   /vitest@0.26.3:
@@ -23683,6 +23151,20 @@ packages:
     resolution: {integrity: sha512-eOpPHogvorZRobNqJGhapa0JdwaxpjVvyBp0QIUMRMSf8ZAlqOdEquKuRmw9Qwu0qXtJIWqFtMkmvJjUZmMjVA==}
     dev: true
 
+  /wait-on@6.0.1:
+    resolution: {integrity: sha512-zht+KASY3usTY5u2LgaNqn/Cd8MukxLGjdcZxT2ns5QzDmTFc4XoWBgC+C/na+sMRZTuVygQoMYwdcVjHnYIVw==}
+    engines: {node: '>=10.0.0'}
+    hasBin: true
+    dependencies:
+      axios: 0.25.0
+      joi: 17.7.0
+      lodash: 4.17.21
+      minimist: 1.2.8
+      rxjs: 7.5.7
+    transitivePeerDependencies:
+      - debug
+    dev: false
+
   /wait-on@6.0.1(debug@4.3.4):
     resolution: {integrity: sha512-zht+KASY3usTY5u2LgaNqn/Cd8MukxLGjdcZxT2ns5QzDmTFc4XoWBgC+C/na+sMRZTuVygQoMYwdcVjHnYIVw==}
     engines: {node: '>=10.0.0'}
@@ -23695,6 +23177,7 @@ packages:
       rxjs: 7.5.7
     transitivePeerDependencies:
       - debug
+    dev: true
 
   /watchpack@2.1.1:
     resolution: {integrity: sha512-Oo7LXCmc1eE1AjyuSBmtC3+Wy4HcV8PxWh2kP6fOl8yTlNS7r0K9l1ao2lrrUza7V39Y3D/BbJgY8VeSlc5JKw==}
@@ -24279,15 +23762,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       '@types/yoga-layout': 1.9.2
-    dev: false
-
-  /zip-local@0.3.5:
-    resolution: {integrity: sha512-GRV3D5TJY+/PqyeRm5CYBs7xVrKTKzljBoEXvocZu0HJ7tPEcgpSOYa2zFIsCZWgKWMuc4U3yMFgFkERGFIB9w==}
-    dependencies:
-      async: 1.5.2
-      graceful-fs: 4.2.10
-      jszip: 2.7.0
-      q: 1.5.1
     dev: false
 
   /zip-stream@4.1.0:


### PR DESCRIPTION
The zip-local package has dependencies with security vulnerabilities:

* https://nvd.nist.gov/vuln/detail/CVE-2022-48285
* https://nvd.nist.gov/vuln/detail/CVE-2021-43138

There is an open pull request on zip-local to fix this (https://github.com/Mostafa-Samir/zip-local/pull/18), but it's two weeks old and the maintainer has not reacted to it. Maybe it's easier to just use adm-zip instead, since it's already in the deps anyway.

I have tried to verify that it's still possible to build java functions, but my experience with Java in Lambda is nil, so I might have broken something.