### PR TITLE
Add support for JSON format in secrets list

### DIFF
--- a/.changeset/stupid-keys-admire.md
+++ b/.changeset/stupid-keys-admire.md
@@ -1,0 +1,6 @@
+---
+"sst": minor
+"@serverless-stack/docs": minor
+---
+
+Add support for JSON format in secrets list

--- a/packages/sst/src/cli/commands/secrets/list.ts
+++ b/packages/sst/src/cli/commands/secrets/list.ts
@@ -7,7 +7,7 @@ export const list = (program: Program) =>
     (yargs) =>
       yargs.positional("format", {
         type: "string",
-        choices: ["table", "env"],
+        choices: ["table", "env", "json"],
       }),
     async (args) => {
       const { Config } = await import("../../../config.js");
@@ -19,6 +19,16 @@ export const list = (program: Program) =>
         return;
       }
       switch (args.format || "table") {
+        case "json":
+          const env = Object.fromEntries(
+            Object.entries(secrets).map(([key, { value, fallback }]) => [
+              key,
+              value || fallback,
+            ])
+          );
+
+          console.log(JSON.stringify(env, null, 2));
+          break;
         case "env":
           for (const [key, value] of Object.entries(secrets)) {
             console.log(`${key}=${value.value || value.fallback}`);

--- a/www/docs/packages/sst.md
+++ b/www/docs/packages/sst.md
@@ -386,7 +386,7 @@ npx sst secrets load <filename>
 
 #### `sst secrets list`
 
-Decrypts and prints out all the secrets with the given `format`; `table` or `env`. Where `env` is the dotenv format. Defaults to `table`.
+Decrypts and prints out all the secrets with the given `format`; `table`, `json`, or `env`. Where `env` is the dotenv format. Defaults to `table`.
 
 ```bash
 npx sst secrets list [format] [options]


### PR DESCRIPTION
This PR adds `json` as a format for `sst secrets list`.