### PR TITLE
Fix AWS profiles broken link

### DIFF
--- a/www/docs/packages/sst.md
+++ b/www/docs/packages/sst.md
@@ -83,7 +83,7 @@ This will run the commands using the locally installed version of SST.
 
 ### AWS profile
 
-Specify the AWS account you want to deploy to by using the `--profile` option. If not specified, uses the default AWS profile. [Read more about AWS profiles here](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html). For example:
+Specify the AWS account you want to deploy to by using the `--profile` option. If not specified, uses the default AWS profile. [Read more about AWS profiles here](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html#cli-configure-files-format). For example:
 
 ```bash
 npx sst deploy --profile=production


### PR DESCRIPTION
The link to the AWS Profiles "cli configure files format" page has an invalid redirect on the Amazon side. It improperly encodes the hash character in the URL when attempting to link the user to the "#cli-configure-files-format" section. I've updated the link to have the correctly (un)encoded hash instead of having Amazon break the link. This is technically a bug on the Amazon side.