### PR TITLE
future/auth: add prompt support for oidc

### DIFF
--- a/.changeset/four-llamas-talk.md
+++ b/.changeset/four-llamas-talk.md
@@ -1,0 +1,5 @@
+---
+"sst": minor
+---
+
+future/auth: add prompt support for oidc

--- a/packages/sst/src/node/future/auth/adapter/google.ts
+++ b/packages/sst/src/node/future/auth/adapter/google.ts
@@ -4,7 +4,10 @@ import { OidcAdapter, OidcBasicConfig } from "./oidc.js";
 
 const issuer = await Issuer.discover("https://accounts.google.com");
 
-type GoogleConfig = OidcBasicConfig & { mode: "oidc" };
+type GoogleConfig = OidcBasicConfig & {
+  mode: "oidc";
+  prompt?: "none" | "consent" | "select_account";
+};
 
 export function GoogleAdapter(config: GoogleConfig) {
   return OidcAdapter({

--- a/packages/sst/src/node/future/auth/adapter/microsoft.ts
+++ b/packages/sst/src/node/future/auth/adapter/microsoft.ts
@@ -7,9 +7,14 @@ import { OidcAdapter, OidcBasicConfig } from "./oidc.js";
 // Business: https://login.microsoftonline.com/{tenant}/v2.0
 // Private: https://login.microsoftonline.com/consumers/v2.0
 
-const issuer = await Issuer.discover("https://login.microsoftonline.com/common/v2.0");
+const issuer = await Issuer.discover(
+  "https://login.microsoftonline.com/common/v2.0"
+);
 
-type MicrosoftConfig = OidcBasicConfig & { mode: "oidc" };
+type MicrosoftConfig = OidcBasicConfig & {
+  mode: "oidc";
+  prompt?: "login" | "none" | "consent" | "select_account";
+};
 
 export function MicrosoftAdapter(config: MicrosoftConfig) {
   return OidcAdapter({

--- a/packages/sst/src/node/future/auth/adapter/oauth.ts
+++ b/packages/sst/src/node/future/auth/adapter/oauth.ts
@@ -22,6 +22,9 @@ export interface OauthBasicConfig {
    * Various scopes requested for the access token
    */
   scope: string;
+  /**
+   * Determines whether users will be prompted for reauthentication and consent
+   */
   prompt?: string;
 }
 

--- a/packages/sst/src/node/future/auth/adapter/oidc.ts
+++ b/packages/sst/src/node/future/auth/adapter/oidc.ts
@@ -13,6 +13,10 @@ export interface OidcBasicConfig {
    * The clientID provided by the third party oauth service
    */
   clientID: string;
+  /**
+   * Determines whether users will be prompted for reauthentication and consent
+   */
+  prompt?: string;
 }
 
 export interface OidcConfig extends OidcBasicConfig {
@@ -39,6 +43,7 @@ export const OidcAdapter = /* @__PURE__ */ (config: OidcConfig) => {
         response_mode: "form_post",
         nonce,
         state,
+        prompt: config.prompt,
       });
 
       useResponse().cookies(


### PR DESCRIPTION
This PR adds support to oidc for the `prompt` parameter in the authorisation URL.

This allows users to authenticate with an app on different accounts using the same provider.

## Links
- Discord [chat](https://discord.com/channels/983865673656705025/1109401107215687752/1109401107215687752)
- Google oidc [doc](https://developers.google.com/identity/openid-connect/openid-connect#authenticationuriparameters) showing prompt param