### PR TITLE
fix(secrets): padding is uneven when there is a fallback

### DIFF
--- a/.changeset/soft-ears-give.md
+++ b/.changeset/soft-ears-give.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+Fix the missing padding due to color in secrets list

--- a/packages/sst/src/cli/commands/secrets/list.ts
+++ b/packages/sst/src/cli/commands/secrets/list.ts
@@ -68,8 +68,13 @@ export const list = (program: Program) =>
             const value = secrets[key].value
               ? secrets[key].value!
               : `${secrets[key].fallback} ${gray("(fallback)")}`;
+
+            const colourPadding = secrets[key].value ? 0 : gray("").length;
+
             console.log(
-              `│ ${key.padEnd(keyLen)} │ ${value.padEnd(valueLen)} │`
+              `│ ${key.padEnd(keyLen)} │ ${value.padEnd(
+                valueLen + colourPadding
+              )} │`
             );
           });
           console.log(


### PR DESCRIPTION
When using `sst secrets list`, if one of the items has a padding. The table is not formatted properly. See below the issue:

![image](https://github.com/serverless-stack/sst/assets/4289486/17a17d75-cee7-45e5-86ef-c8e6511e8ac8)

The reason is because of the colouring is adding some "hidden" characters that isn't printed in the terminal. So this PR fixes that by padding it with all the extra characters that the colouring is adding into the string.