### PR TITLE
future/auth - forward query params to authorization endpoint

### DIFF
--- a/.changeset/little-roses-beg.md
+++ b/.changeset/little-roses-beg.md
@@ -1,0 +1,5 @@
+---
+"sst": minor
+---
+
+future/auth - forward query params to authorization endpoint

--- a/packages/sst/src/node/future/auth/adapter/google.ts
+++ b/packages/sst/src/node/future/auth/adapter/google.ts
@@ -1,18 +1,35 @@
 import { Issuer } from "openid-client";
-import { Adapter } from "./adapter.js";
 import { OidcAdapter, OidcBasicConfig } from "./oidc.js";
+import { OauthAdapter, OauthBasicConfig } from "./oauth.js";
 
 const issuer = await Issuer.discover("https://accounts.google.com");
 
-type GoogleConfig = OidcBasicConfig & {
-  mode: "oidc";
-  prompt?: "none" | "consent" | "select_account";
-};
+type GooglePrompt = "none" | "consent" | "select_account";
+type GoogleAccessType = "offline" | "online";
+
+type GoogleConfig =
+  | (OauthBasicConfig & {
+      mode: "oauth";
+      prompt?: GooglePrompt;
+      accessType?: GoogleAccessType;
+    })
+  | (OidcBasicConfig & { mode: "oidc"; prompt?: GooglePrompt });
 
 export function GoogleAdapter(config: GoogleConfig) {
+  /* @__PURE__ */
+  if (config.mode === "oauth") {
+    return OauthAdapter({
+      issuer,
+      ...config,
+      params: {
+        ...(config.accessType && { access_type: config.accessType }),
+        ...config.params,
+      },
+    });
+  }
   return OidcAdapter({
     issuer,
     scope: "openid email profile",
     ...config,
-  }) satisfies Adapter;
+  });
 }

--- a/packages/sst/src/node/future/auth/adapter/oauth.ts
+++ b/packages/sst/src/node/future/auth/adapter/oauth.ts
@@ -26,6 +26,10 @@ export interface OauthBasicConfig {
    * Determines whether users will be prompted for reauthentication and consent
    */
   prompt?: string;
+  /**
+   * Additional parameters to be passed to the authorization endpoint
+   */
+  params?: Record<string, string>;
 }
 
 export interface OauthConfig extends OauthBasicConfig {
@@ -57,6 +61,7 @@ export const OauthAdapter =
           code_challenge_method: "S256",
           state,
           prompt: config.prompt,
+          ...config.params,
         });
 
         useResponse().cookies(


### PR DESCRIPTION
- Adds ability to pass through params to oauth 2.0 auth endpoints. This is needed for cases like Google where `access_type` param controls whether a refresh token is returned.
- Added Google Oauth config as only had oidc in future/auth
- Added typed `accessType` param to google config

### Links
- [Google access_type param](https://developers.google.com/identity/protocols/oauth2/web-server#offline)
- [Next auth implementation thats pretty similar](https://github.com/nextauthjs/next-auth/blob/461b52ea4f55d740b3b94de800d105a9bfc854ef/packages/next-auth/src/core/lib/oauth/authorization-url.ts#L31)