### PR TITLE
Suggest where to place sst create command.

### DIFF
--- a/www/docs/start/astro.md
+++ b/www/docs/start/astro.md
@@ -57,6 +57,7 @@ Now initialize SST in your project root.
 <TabItem value="npm">
 
 ```bash
+cd astro-project
 npx create-sst@latest
 ```
 
@@ -64,6 +65,7 @@ npx create-sst@latest
 <TabItem value="yarn">
 
 ```bash
+cd astro-project
 yarn create sst
 ```
 
@@ -71,6 +73,7 @@ yarn create sst
 <TabItem value="pnpm">
 
 ```bash
+cd astro-project
 pnpm create sst
 ```
 

--- a/www/docs/start/nextjs.md
+++ b/www/docs/start/nextjs.md
@@ -57,6 +57,7 @@ Now initialize SST in your project root.
 <TabItem value="npm">
 
 ```bash
+cd my-app
 npx create-sst@latest
 ```
 
@@ -64,6 +65,7 @@ npx create-sst@latest
 <TabItem value="yarn">
 
 ```bash
+cd my-app
 yarn create sst
 ```
 
@@ -71,6 +73,7 @@ yarn create sst
 <TabItem value="pnpm">
 
 ```bash
+cd my-app
 pnpm create sst
 ```
 

--- a/www/docs/start/remix.md
+++ b/www/docs/start/remix.md
@@ -57,6 +57,7 @@ Now initialize SST in your project root.
 <TabItem value="npm">
 
 ```bash
+cd my-remix-app
 npx create-sst@latest
 ```
 
@@ -64,6 +65,7 @@ npx create-sst@latest
 <TabItem value="yarn">
 
 ```bash
+cd my-remix-app
 yarn create sst
 ```
 
@@ -71,6 +73,7 @@ yarn create sst
 <TabItem value="pnpm">
 
 ```bash
+cd my-remix-app
 pnpm create sst
 ```
 


### PR DESCRIPTION
According to used web framework, suggest where to place sst create command.
The cd command suggest to navigate to default project names, when the framework creates a new folder (astro, next, remix).
Svelte and Solid frameworks uses current directory and isn't necesary to move.
