### PR TITLE
Update long-running-jobs docs

### DIFF
--- a/www/docs/long-running-jobs.md
+++ b/www/docs/long-running-jobs.md
@@ -302,7 +302,7 @@ We evaluated both CodeBuild and ECS Fargate as the backing service for `Job`.
 Both services are similar in the way that they can run code inside a docker container environment. We decided to go with CodeBuild because:
 
 - It can be deployed without a VPC
-- It offers a free tier of 100 build minutes per month
+- It offers a free tier of 100 build minutes per month (for the general1.small instance type, general1.medium and general1.large aren't included in the free-tier)
 - A CodeBuild project is a single AWS resource, and is much faster to deploy
 
 As we collect more feedback on the usage, we are open to switching to using Fargate. When we do, it will be a seamless switch as the implementation details are not exposed.


### PR DESCRIPTION
Update the SST jobs page to make sure it's conveyed that only general1.small is included in free-tier.

One more addition could be changing [this section](https://docs.sst.dev/long-running-jobs#how-much-does-it-cost-to-use-job)

```diff
-...The general1 instance types are used.
+...The general1 instance types are used. By default SST jobs are configured to use general1.medium (7GB) instances.
```