### PR TITLE
Documentation: Fixed spelling mistakes in documentation

### DIFF
--- a/packages/console/src/App/Stage/Buckets/Detail.tsx
+++ b/packages/console/src/App/Stage/Buckets/Detail.tsx
@@ -216,7 +216,7 @@ function formatFileSize(bytes: number): string {
   const i = Math.floor(Math.log(bytes) / Math.log(k));
   const num = parseFloat((bytes / Math.pow(k, i)).toFixed(2));
 
-  // Handle 1 Byte should be singluar, otherwise plural
+  // Handle 1 Byte should be singular, otherwise plural
   const unit = sizes[i] + (i === 0 && num !== 1 ? "s" : "");
 
   return `${num} ${unit}`;

--- a/packages/console/src/data/aws/stacks.ts
+++ b/packages/console/src/data/aws/stacks.ts
@@ -113,7 +113,7 @@ export function useStacks() {
                 const constructs = ((await resp.json()) || []) as Metadata[];
                 console.log(constructs);
                 // Get the stack info. Note that if stack is not found in CloudFormation,
-                // supress the error.
+                // suppress the error.
                 let describe;
                 try {
                   describe = await cf.send(

--- a/packages/sst/src/bootstrap.ts
+++ b/packages/sst/src/bootstrap.ts
@@ -100,7 +100,7 @@ async function loadCDKStatus() {
     }
 
     // Check CDK bootstrap stack is up to date
-    // note: there is no a programmatical way to get the minimal required version
+    // note: there is no programmatic way to get the minimal required version
     //       of CDK bootstrap stack. We are going to hardcode it to 14 for now,
     //       which is the latest version as of CDK v2.62.2
     const output = stacks[0].Outputs?.find(

--- a/packages/sst/src/cdk/cloudformation-deployments.ts
+++ b/packages/sst/src/cdk/cloudformation-deployments.ts
@@ -327,7 +327,7 @@ export interface BuildStackAssetsOptions {
   readonly roleArn?: string;
 
   /**
-   * Options to pass on to `buildAsests()` function
+   * Options to pass on to `buildAssets()` function
    */
   readonly buildOptions?: BuildAssetsOptions;
 }
@@ -341,7 +341,7 @@ interface PublishStackAssetsOptions {
   readonly buildAssets?: boolean;
 
   /**
-   * Options to pass on to `publishAsests()` function
+   * Options to pass on to `publishAssets()` function
    */
   readonly publishOptions?: Omit<PublishAssetsOptions, "buildAssets">;
 }

--- a/packages/sst/src/cli/commands/bind.ts
+++ b/packages/sst/src/cli/commands/bind.ts
@@ -288,7 +288,7 @@ export const bind = (program: Program) =>
           const credentials = await assumeSsrRole(roleArn);
           if (!credentials) return;
 
-          // refresh crecentials 1 minute before expiration
+          // refresh credentials 1 minute before expiration
           const expireAt = credentials.Expiration!.getTime() - 60000;
           clearTimeout(timer);
           timer = setTimeout(() => {
@@ -376,7 +376,7 @@ export const bind = (program: Program) =>
             return credentials;
           };
 
-          // Assue role with max duration first. This can fail if chaining roles, or if
+          // Assume role with max duration first. This can fail if chaining roles, or if
           // the role has a max duration set. If it fails, assume role with 1 hour duration.
           let err: any;
           try {

--- a/packages/sst/src/cli/ui/functions.tsx
+++ b/packages/sst/src/cli/ui/functions.tsx
@@ -53,7 +53,7 @@ export function Functions() {
       });
     });
 
-    // This is all ugly but the timeouts are for UI smootheness
+    // This is all ugly but the timeouts are for UI smoothness
     const success = bus.subscribe("function.success", (evt) => {
       function print(input: Pending, diff: number) {
         setTimeout(

--- a/packages/sst/src/constructs/Auth.ts
+++ b/packages/sst/src/constructs/Auth.ts
@@ -209,7 +209,7 @@ export class Auth extends Construct implements SSTConstruct {
         },
       });
 
-      // Auth construct has two types of Function bindinds:
+      // Auth construct has two types of Function bindings:
       // - Api routes: bindings defined in `getFunctionBinding()`
       //     ie. calling `bind([auth])` will grant functions access to the public key
       // - Auth authenticator: binds manually. Need to grant access to the prefix and private key

--- a/packages/sst/src/constructs/Bucket.ts
+++ b/packages/sst/src/constructs/Bucket.ts
@@ -203,7 +203,7 @@ export interface BucketProps {
    */
   cors?: boolean | BucketCorsRule[];
   /**
-   * Block public access to this bucket. Setting this to `true` alllows uploading objects with public ACLs.
+   * Block public access to this bucket. Setting this to `true` allows uploading objects with public ACLs.
    * Note that setting to `true` does not necessarily mean that the bucket is completely accessible to the public. Rather, it enables the granting of public permissions through public ACLs.
    * @default false
    * @example

--- a/packages/sst/src/constructs/EdgeFunction.ts
+++ b/packages/sst/src/constructs/EdgeFunction.ts
@@ -85,8 +85,8 @@ export class EdgeFunction extends Construct {
 
     // Override scope
     // note: this is intended to be used internally by SST to make constructs
-    //       backwards compatible when the hirechical structure of the constructs
-    //       changes. When the hirerchical structure changes, the child AWS
+    //       backwards compatible when the hierarchical structure of the constructs
+    //       changes. When the hierarchical structure changes, the child AWS
     //       resources' logical ID will change. And CloudFormation will recreate
     //       them.
     this.scope = props.scopeOverride || this;

--- a/packages/sst/src/constructs/Function.ts
+++ b/packages/sst/src/constructs/Function.ts
@@ -326,7 +326,7 @@ export interface FunctionProps
    *
    * Note that, if a Layer is created in a stack (say `stackA`) and is referenced in another stack (say `stackB`), SST automatically creates an SSM parameter in `stackA` with the Layer's ARN. And in `stackB`, SST reads the ARN from the SSM parameter, and then imports the Layer.
    *
-   *  This is to get around the limitation that a Lambda Layer ARN cannot be referenced across stacks via a stack export. The Layer ARN contains a version number that is incremented everytime the Layer is modified. When you refer to a Layer's ARN across stacks, a CloudFormation export is created. However, CloudFormation does not allow an exported value to be updated. Once exported, if you try to deploy the updated layer, the CloudFormation update will fail. You can read more about this issue here - https://github.com/serverless-stack/sst/issues/549.
+   *  This is to get around the limitation that a Lambda Layer ARN cannot be referenced across stacks via a stack export. The Layer ARN contains a version number that is incremented every time the Layer is modified. When you refer to a Layer's ARN across stacks, a CloudFormation export is created. However, CloudFormation does not allow an exported value to be updated. Once exported, if you try to deploy the updated layer, the CloudFormation update will fail. You can read more about this issue here - https://github.com/serverless-stack/sst/issues/549.
    *
    * @default no layers
    *

--- a/packages/sst/src/constructs/KinesisStream.ts
+++ b/packages/sst/src/constructs/KinesisStream.ts
@@ -41,7 +41,7 @@ export interface KinesisStreamConsumerProps {
   function: FunctionDefinition;
   cdk?: {
     /**
-     * Override the interally created event source
+     * Override the internally created event source
      *
      * @example
      * ```js

--- a/packages/sst/src/constructs/NextjsSite.ts
+++ b/packages/sst/src/constructs/NextjsSite.ts
@@ -264,7 +264,7 @@ export class NextjsSite extends SsrSite {
      *
      * - SSR pages (user transition)
      *  Use case: When the page uses getServerSideProps(), and you request this page on
-     *            client-side page trasitions. Next.js sends an API request to the server,
+     *            client-side page transitions. Next.js sends an API request to the server,
      *            which runs getServerSideProps()
      *  Request: /_next/data/_-fpIB1rqWyRD-EJO59pO/myPage.json
      *  Response cache:

--- a/packages/sst/src/constructs/RDS.ts
+++ b/packages/sst/src/constructs/RDS.ts
@@ -121,7 +121,7 @@ export interface RDSProps {
      */
     id?: string;
     /**
-     * Configure the internallly created RDS cluster.
+     * Configure the internally created RDS cluster.
      *
      * @example
      * ```js
@@ -497,7 +497,7 @@ export class RDS extends Construct implements SSTConstruct {
         RDS_SECRET: this.cdk.cluster.secret!.secretArn,
         RDS_DATABASE: defaultDatabaseName,
         RDS_ENGINE_MODE: engine.includes("postgres") ? "postgres" : "mysql",
-        // for live development, perserve the migrations path so the migrator
+        // for live development, preserve the migrations path so the migrator
         // can locate the migration files
         RDS_MIGRATIONS_PATH:
           app.mode === "dev" ? migrations : migrationsDestination,

--- a/packages/sst/src/constructs/RemixSite.ts
+++ b/packages/sst/src/constructs/RemixSite.ts
@@ -105,7 +105,7 @@ export class RemixSite extends SsrSite {
       handler
     );
 
-    // Copy the Remix polyfil to the server build directory
+    // Copy the Remix polyfill to the server build directory
     //
     // Note: We need to ensure that the polyfills are injected above other code that
     // will depend on them. Importing them within the top of the lambda code

--- a/packages/sst/src/constructs/SsrSite.ts
+++ b/packages/sst/src/constructs/SsrSite.ts
@@ -253,7 +253,7 @@ export interface SsrSiteProps {
      */
     id?: string;
     /**
-     * Allows you to override default settings this construct uses internally to ceate the bucket
+     * Allows you to override default settings this construct uses internally to create the bucket
      */
     bucket?: BucketProps | IBucket;
     /**
@@ -265,7 +265,7 @@ export interface SsrSiteProps {
      * Override the CloudFront cache policy properties for responses from the
      * server rendering Lambda.
      *
-     * @note The default cache policy that is used in the abscene of this property
+     * @note The default cache policy that is used in the absence of this property
      * is one that performs no caching of the server response.
      */
     serverCachePolicy?: ICachePolicy;

--- a/packages/sst/src/constructs/cdk/certificate-base.ts
+++ b/packages/sst/src/constructs/cdk/certificate-base.ts
@@ -11,7 +11,7 @@ export abstract class CertificateBase extends Resource implements ICertificate {
   public abstract readonly certificateArn: string;
 
   /**
-   * If the certificate is provisionned in a different region than the
+   * If the certificate is provisioned in a different region than the
    * containing stack, this should be the region in which the certificate lives
    * so we can correctly create `Metric` instances.
    */

--- a/packages/sst/src/constructs/cdk/dns-validated-certificate.ts
+++ b/packages/sst/src/constructs/cdk/dns-validated-certificate.ts
@@ -209,7 +209,7 @@ export class DnsValidatedCertificate
           Region: props.region,
           Route53Endpoint: props.route53Endpoint,
           RemovalPolicy: Lazy.any({ produce: () => this._removalPolicy }),
-          // Custom resources properties are always converted to strings; might as well be explict here.
+          // Custom resources properties are always converted to strings; might as well be explicit here.
           CleanupRecords: props.cleanupRoute53Records ? "true" : undefined,
           Tags: Lazy.list({ produce: () => this.tags.renderTags() }),
         },

--- a/packages/sst/src/constructs/deprecated/NextjsSite.ts
+++ b/packages/sst/src/constructs/deprecated/NextjsSite.ts
@@ -169,7 +169,7 @@ export interface NextjsSiteProps {
      */
     id?: string;
     /**
-     * Allows you to override default settings this construct uses internally to ceate the bucket
+     * Allows you to override default settings this construct uses internally to create the bucket
      */
     bucket?: s3.BucketProps | s3.IBucket;
     /**

--- a/packages/sst/src/constructs/util/permission.ts
+++ b/packages/sst/src/constructs/util/permission.ts
@@ -269,8 +269,8 @@ function permissionsToStatementsAndGrants(
       );
     } else if ((permission as any).clusterArn) {
       // For ServerlessCluster, we need to grant:
-      // - permisssions to access the Data API;
-      // - permisssions to access the Secret Manager (required by Data API).
+      // - permissions to access the Data API;
+      // - permissions to access the Secret Manager (required by Data API).
       // No need to grant the permissions for IAM database authentication
       statements.push(
         buildPolicyStatement("rds-data:*", [(permission as any).clusterArn])

--- a/packages/sst/src/context/context.ts
+++ b/packages/sst/src/context/context.ts
@@ -48,7 +48,7 @@ function create<C>(cb?: (() => C) | string, name?: string) {
         reset();
       }
 
-      // If the context is already set, we need to reset its dependants
+      // If the context is already set, we need to reset its dependents
       resetDependencies(id);
 
       state.contexts.set(id, {

--- a/packages/sst/src/node/auth/adapter/facebook.ts
+++ b/packages/sst/src/node/auth/adapter/facebook.ts
@@ -6,7 +6,7 @@ import { OauthAdapter, OauthBasicConfig } from "./oauth.js";
 // are not passed to Lambda event object. It is likely that Facebook only wants
 // to support redirecting to a frontend uri.
 //
-// We are only going to suppor the OAuth flow for now. More details about the flow:
+// We are only going to support the OAuth flow for now. More details about the flow:
 // https://developers.facebook.com/docs/facebook-login/guides/advanced/oidc-token
 //
 // Also note that Facebook's discover uri does not work for the OAuth flow, as the

--- a/packages/sst/support/custom-resources/cloudfront-invalidator.ts
+++ b/packages/sst/support/custom-resources/cloudfront-invalidator.ts
@@ -61,7 +61,7 @@ async function wait(distributionId: string, invalidationId: string) {
       }
     );
   } catch (e) {
-    // supress errors
+    // suppress errors
     console.error(e);
   }
 }

--- a/packages/sst/support/edge-function/edge-lambda-version.ts
+++ b/packages/sst/support/edge-function/edge-lambda-version.ts
@@ -150,12 +150,12 @@ async function deleteOldVersions(functionName: string) {
           .promise();
         log("response", resp);
       } catch (e) {
-        // Supress error because a version can fail to remove if still in use.
+        // suppress error because a version can fail to remove if still in use.
         log(`deleteVersion error`, e);
       }
     }
   } catch (e) {
-    // Supress error because it is fine if a specific version fails to remove.
+    // suppress error because it is fine if a specific version fails to remove.
     // All versions will be removed upon removing the function.
     log(`deleteOldVersions error`, e);
   }

--- a/packages/sst/support/nodejs-runtime/index.ts
+++ b/packages/sst/support/nodejs-runtime/index.ts
@@ -125,11 +125,11 @@ while (true) {
           Number(result.headers["lambda-runtime-deadline-ms"]) - Date.now(),
           0
         ),
-      // If identity is null, we want to mimick AWS behavior and return undefined
+      // If identity is null, we want to mimic AWS behavior and return undefined
       identity:
         JSON.parse(result.headers["lambda-runtime-cognito-identity"]) ??
         undefined,
-      // If clientContext is null, we want to mimick AWS behavior and return undefined
+      // If clientContext is null, we want to mimic AWS behavior and return undefined
       clientContext:
         JSON.parse(result.headers["lambda-runtime-client-context"]) ??
         undefined,

--- a/packages/sst/support/python-runtime/runtime.py
+++ b/packages/sst/support/python-runtime/runtime.py
@@ -27,9 +27,9 @@ class Context(object):
         self.aws_request_id = aws_request_id
         self.memory_limit_in_mb = os.environ['AWS_LAMBDA_FUNCTION_MEMORY_SIZE']
         self.deadline_ms = deadline_ms
-        # If identity is null, we want to mimick AWS behavior and return an object with None values
+        # If identity is null, we want to mimic AWS behavior and return an object with None values
         self.identity = Identity(**json.loads(identity)) if identity != 'null' else Identity(cognito_identity_id = None, cognito_identity_pool_id = None)
-        # If client_context is null, we want to mimick AWS behavior and return None
+        # If client_context is null, we want to mimic AWS behavior and return None
         self.client_context = ClientContext(**json.loads(client_context)) if client_context != 'null' else None
         self.log_group_name = log_group_name
         self.log_stream_name = log_stream_name

--- a/packages/sst/test/constructs/Api.test.ts
+++ b/packages/sst/test/constructs/Api.test.ts
@@ -264,7 +264,7 @@ test("accessLog-props-with-retention-invalid", async () => {
   expect(() => {
     new Api(stack, "Api", {
       accessLog: {
-        // @ts-ignore Allow non-existant value
+        // @ts-ignore Allow non-existent value
         retention: "NOT_EXIST",
       },
     });
@@ -1065,7 +1065,7 @@ test("defaults: authorizer jwt missing authorizer", async () => {
         "GET /": "test/lambda.handler",
       },
       defaults: {
-        // @ts-ignore Allow non-existant value
+        // @ts-ignore Allow non-existent value
         authorizer: "foo",
       },
     });
@@ -1418,7 +1418,7 @@ test("routes: ApiFunctionRouteProps-authorizer-not-found", async () => {
           function: {
             handler: "test/lambda.handler",
           },
-          // @ts-ignore Allow non-existant value
+          // @ts-ignore Allow non-existent value
           authorizer: "ABC",
         },
       },
@@ -1621,7 +1621,7 @@ test("routes: ApiGraphQLRouteProps-function-string", async () => {
 test("routes: ApiAlbRouteProps method is undefined", async () => {
   const stack = new Stack(await createApp(), "stack");
 
-  // Ceate ALB listener
+  // Create ALB listener
   const vpc = new ec2.Vpc(stack, "VPC");
   const lb = new elb.ApplicationLoadBalancer(stack, "LB", { vpc });
   const listener = lb.addListener("Listener", { port: 80 });
@@ -1675,7 +1675,7 @@ test("routes: ApiAlbRouteProps method is undefined", async () => {
 test("routes: ApiAlbRouteProps method is HttpMethod", async () => {
   const stack = new Stack(await createApp(), "stack");
 
-  // Ceate ALB listener
+  // Create ALB listener
   const vpc = new ec2.Vpc(stack, "VPC");
   const lb = new elb.ApplicationLoadBalancer(stack, "LB", { vpc });
   const listener = lb.addListener("Listener", { port: 80 });
@@ -1732,7 +1732,7 @@ test("routes: ApiAlbRouteProps method is HttpMethod", async () => {
 test("routes: ApiNlbRouteProps method is undefined", async () => {
   const stack = new Stack(await createApp(), "stack");
 
-  // Ceate NLB listener
+  // Create NLB listener
   const vpc = new ec2.Vpc(stack, "VPC");
   const lb = new elb.NetworkLoadBalancer(stack, "LB", { vpc });
   const listener = lb.addListener("Listener", { port: 80 });
@@ -1786,7 +1786,7 @@ test("routes: ApiNlbRouteProps method is undefined", async () => {
 test("routes: ApiNlbRouteProps method is HttpMethod", async () => {
   const stack = new Stack(await createApp(), "stack");
 
-  // Ceate NLB listener
+  // Create NLB listener
   const vpc = new ec2.Vpc(stack, "VPC");
   const lb = new elb.NetworkLoadBalancer(stack, "LB", { vpc });
   const listener = lb.addListener("Listener", { port: 80 });

--- a/packages/sst/test/constructs/ApiGatewayV1Api.test.ts
+++ b/packages/sst/test/constructs/ApiGatewayV1Api.test.ts
@@ -312,7 +312,7 @@ test("accessLog-props-retention-invalid", async () => {
   expect(() => {
     new ApiGatewayV1Api(stack, "Api", {
       accessLog: {
-        // @ts-ignore Allow non-existant value
+        // @ts-ignore Allow non-existent value
         retention: "NOT_EXIST",
       },
     });

--- a/packages/sst/test/constructs/WebSocketApi.test.ts
+++ b/packages/sst/test/constructs/WebSocketApi.test.ts
@@ -208,7 +208,7 @@ test("accessLog-props-with-retention-invalid", async () => {
   expect(() => {
     new WebSocketApi(stack, "Api", {
       accessLog: {
-        // @ts-ignore Allow non-existant value
+        // @ts-ignore Allow non-existent value
         retention: "NOT_EXIST",
       },
     });

--- a/www/docs/advanced/monitoring.md
+++ b/www/docs/advanced/monitoring.md
@@ -102,7 +102,7 @@ export default {
     if (enableDatadog) {
       await app.finish();
 
-      // Attach the Datadog contruct to each stack
+      // Attach the Datadog construct to each stack
       app.node.children.forEach((stack) => {
         if (stack instanceof Stack) {
           const datadog = new Datadog(stack, "datadog", {

--- a/www/docs/constructs/v0/Function.md
+++ b/www/docs/constructs/v0/Function.md
@@ -421,7 +421,7 @@ A list of Layers to add to the function's execution environment.
 
 Note that, if a Layer is created in a stack (say `stackA`) and is referenced in another stack (say `stackB`), SST automatically creates an SSM parameter in `stackA` with the Layer's ARN. And in `stackB`, SST reads the ARN from the SSM parameter, and then imports the Layer.
 
-This is to get around the limitation that a Lambda Layer ARN cannot be referenced across stacks via a stack export. The Layer ARN contains a version number that is incremented everytime the Layer is modified. When you refer to a Layer's ARN across stacks, a CloudFormation export is created. However, CloudFormation does not allow an exported value to be updated. Once exported, if you try to deploy the updated layer, the CloudFormation update will fail. You can [read more about this issue here](https://github.com/serverless-stack/sst/issues/549).
+This is to get around the limitation that a Lambda Layer ARN cannot be referenced across stacks via a stack export. The Layer ARN contains a version number that is incremented every time the Layer is modified. When you refer to a Layer's ARN across stacks, a CloudFormation export is created. However, CloudFormation does not allow an exported value to be updated. Once exported, if you try to deploy the updated layer, the CloudFormation update will fail. You can [read more about this issue here](https://github.com/serverless-stack/sst/issues/549).
 
 ## FunctionDefinition
 

--- a/www/docs/constructs/v1/Function.tsdoc.md
+++ b/www/docs/constructs/v1/Function.tsdoc.md
@@ -172,7 +172,7 @@ _Default_ : <span class="mono">no layers</span>
 A list of Layers to add to the function's execution environment.
 Note that, if a Layer is created in a stack (say `stackA`) and is referenced in another stack (say `stackB`), SST automatically creates an SSM parameter in `stackA` with the Layer's ARN. And in `stackB`, SST reads the ARN from the SSM parameter, and then imports the Layer.
 
- This is to get around the limitation that a Lambda Layer ARN cannot be referenced across stacks via a stack export. The Layer ARN contains a version number that is incremented everytime the Layer is modified. When you refer to a Layer's ARN across stacks, a CloudFormation export is created. However, CloudFormation does not allow an exported value to be updated. Once exported, if you try to deploy the updated layer, the CloudFormation update will fail. You can read more about this issue here - https://github.com/serverless-stack/sst/issues/549.
+ This is to get around the limitation that a Lambda Layer ARN cannot be referenced across stacks via a stack export. The Layer ARN contains a version number that is incremented every time the Layer is modified. When you refer to a Layer's ARN across stacks, a CloudFormation export is created. However, CloudFormation does not allow an exported value to be updated. Once exported, if you try to deploy the updated layer, the CloudFormation update will fail. You can read more about this issue here - https://github.com/serverless-stack/sst/issues/549.
 
 
 ```js

--- a/www/docs/constructs/v1/KinesisStream.tsdoc.md
+++ b/www/docs/constructs/v1/KinesisStream.tsdoc.md
@@ -242,7 +242,7 @@ new KinesisStream(stack, "Stream", {
 
 _Type_ : <span class="mono">[KinesisEventSourceProps](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_lambda.KinesisEventSourceProps.html)</span>
 
-Override the interally created event source
+Override the internally created event source
 
 
 ```js

--- a/www/docs/constructs/v1/NextjsSite.tsdoc.md
+++ b/www/docs/constructs/v1/NextjsSite.tsdoc.md
@@ -149,7 +149,7 @@ While deploying, SST waits for the CloudFront cache invalidation process to fini
 
 _Type_ : <span class='mono'><span class="mono">[IBucket](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_s3.IBucket.html)</span> | <span class="mono">[BucketProps](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_s3.BucketProps.html)</span></span>
 
-Allows you to override default settings this construct uses internally to ceate the bucket
+Allows you to override default settings this construct uses internally to create the bucket
 
 
 ### cdk.cachePolicies.imageCachePolicy?

--- a/www/docs/constructs/v1/RDS.tsdoc.md
+++ b/www/docs/constructs/v1/RDS.tsdoc.md
@@ -118,7 +118,7 @@ new RDS(stack, "Database", {
 
 _Type_ : <span class='mono'><span class="mono">[IServerlessCluster](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_rds.IServerlessCluster.html)</span> | <span class="mono">[RDSCdkServerlessClusterProps](#rdscdkserverlessclusterprops)</span></span>
 
-Configure the internallly created RDS cluster.
+Configure the internally created RDS cluster.
 
 
 ```js

--- a/www/docs/constructs/v1/RemixSite.tsdoc.md
+++ b/www/docs/constructs/v1/RemixSite.tsdoc.md
@@ -119,7 +119,7 @@ While deploying, SST waits for the CloudFront cache invalidation process to fini
 
 _Type_ : <span class='mono'><span class="mono">[IBucket](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_s3.IBucket.html)</span> | <span class="mono">[BucketProps](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_s3.BucketProps.html)</span></span>
 
-Allows you to override default settings this construct uses internally to ceate the bucket
+Allows you to override default settings this construct uses internally to create the bucket
 
 
 ### cdk.cachePolicies.buildCachePolicy?
@@ -135,7 +135,7 @@ _Type_ : <span class="mono">[ICachePolicy](https://docs.aws.amazon.com/cdk/api/v
 Override the CloudFront cache policy properties for responses from the
 server rendering Lambda.
 
-The default cache policy that is used in the abscene of this property
+The default cache policy that is used in the absence of this property
 is one that performs no caching of the server response.
 
 ### cdk.cachePolicies.staticsCachePolicy?

--- a/www/docs/constructs/v1/StaticSite.tsdoc.md
+++ b/www/docs/constructs/v1/StaticSite.tsdoc.md
@@ -258,7 +258,7 @@ new StaticSite(stack, "frontend", {
 
 _Type_ : <span class='mono'><span class="mono">[IBucket](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_s3.IBucket.html)</span> | <span class="mono">[BucketProps](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_s3.BucketProps.html)</span></span>
 
-Allows you to override default settings this construct uses internally to ceate the bucket
+Allows you to override default settings this construct uses internally to create the bucket
 
 
 ```js

--- a/www/docs/constructs/v1/ViteStaticSite.tsdoc.md
+++ b/www/docs/constructs/v1/ViteStaticSite.tsdoc.md
@@ -273,7 +273,7 @@ new ViteStaticSite(stack, "frontend", {
 
 _Type_ : <span class='mono'><span class="mono">[IBucket](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_s3.IBucket.html)</span> | <span class="mono">[BucketProps](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_s3.BucketProps.html)</span></span>
 
-Allows you to override default settings this construct uses internally to ceate the bucket
+Allows you to override default settings this construct uses internally to create the bucket
 
 
 ```js


### PR DESCRIPTION
Ran Cspell on the code comments and documentation and fixed whatever spelling mistakes and grammatical errors I found. 
I did not touch any of the code whatsoever.