### PR TITLE
Changed cloudfront serverOrigin readTimeout to 60s

### DIFF
--- a/packages/sst/src/constructs/NextjsSite.ts
+++ b/packages/sst/src/constructs/NextjsSite.ts
@@ -289,7 +289,9 @@ export class NextjsSite extends SsrSite {
     const serverFnUrl = this.serverLambdaForRegional!.addFunctionUrl({
       authType: FunctionUrlAuthType.NONE,
     });
-    const serverOrigin = new HttpOrigin(Fn.parseDomainName(serverFnUrl.url));
+    const serverOrigin = new HttpOrigin(Fn.parseDomainName(serverFnUrl.url), {
+      readTimeout: CdkDuration.seconds(60),
+    });
     const cachePolicy =
       cdk?.serverCachePolicy ??
       this.buildServerCachePolicy([


### PR DESCRIPTION
I suppose we can make it more configurable, but I am not sure what to add to the construct. I think it is fine too if we leave it at maximum(60s) as if the lambda timeout is lower than 60s then CloudFront will forward the timeout error.