### PR TITLE
remove console.log from sqsQueueProps.visibilityTimeout if condition in Queue.js

### DIFF
--- a/packages/sst/src/constructs/Queue.ts
+++ b/packages/sst/src/constructs/Queue.ts
@@ -340,8 +340,6 @@ export class Queue extends Construct implements SSTConstruct {
           !sqsQueueProps.visibilityTimeout ||
           sqsQueueProps.visibilityTimeout.toSeconds() < 900
         ) {
-          // TODO
-          console.log(toCdkDuration("900 seconds"));
           debugOverrideProps = {
             visibilityTimeout: toCdkDuration("900 seconds"),
           };


### PR DESCRIPTION
remove console.log from sqsQueueProps.visibilityTimeout if condition