### PR TITLE
docs: document bootstrap config option

### DIFF
--- a/www/docs/configuring-sst.md
+++ b/www/docs/configuring-sst.md
@@ -91,6 +91,9 @@ Here's the full list of config options that can be returned:
   - **`fileAssetPublishingRoleArn`** IAM role used to publish file assets to the S3 bucket
   - **`imageAssetPublishingRoleArn`** IAM role used to publish image assets to the ECR repository
   - **`cloudFormationExecutionRole`** IAM role assumed by the CloudFormation to deploy
+- **`bootstrap`**
+  - **`stackName`** The name to use for the bootstrap stack
+  - **`tags`** Tags to use for the bootstrap stack
 
 \*These won't take effect if the CLI flag for it is specified.
 


### PR DESCRIPTION
The bootstrap config option is typed in SSTConfig, but not mentioned in the docs. This PR adds bootstrap to the config options to make it easier to discover how to change the bootstrap stack name and tags.

Closes #2973