### PR TITLE
feat: add --to argument to diff else it can only use the default buildDir

### DIFF
--- a/.changeset/many-moons-change.md
+++ b/.changeset/many-moons-change.md
@@ -1,0 +1,5 @@
+---
+"sst": minor
+---
+
+add --to option to diff to prevent it building to .sst/dist

--- a/packages/sst/src/cli/commands/diff.ts
+++ b/packages/sst/src/cli/commands/diff.ts
@@ -6,10 +6,15 @@ export const diff = (program: Program) =>
     "diff",
     "Compare your app with what is deployed on AWS",
     (yargs) =>
-      yargs.option("dev", {
-        type: "boolean",
-        describe: "Compare in dev mode",
-      }),
+      yargs
+	.option("dev", {
+          type: "boolean",
+          describe: "Compare in dev mode",
+	})
+	.option("to", {
+          type: "string",
+          describe: "Output directory, defaults to .sst/dist",
+	}),
     async (args) => {
       const { useProject } = await import("../../project.js");
       const { Stacks } = await import("../../stacks/index.js");
@@ -25,6 +30,7 @@ export const diff = (program: Program) =>
       const [_metafile, sstConfig] = await Stacks.load(project.paths.config);
       const assembly = await Stacks.synth({
         fn: sstConfig.stacks,
+        buildDir: args.to,
         mode: args.dev ? "dev" : "deploy",
       });
 


### PR DESCRIPTION
This makes it compatible with the build command. Else build builds to its own, but diff still creates the .sst/dist folder, and that does not work well within nx.

As we know have to provide arguments to build and deploy to make this work, I suggest buildDir becomes a single setting at a single spot somewhere.