### PR TITLE
arm64 docker build support for Python functions

### DIFF
--- a/.changeset/clawsl-change.md
+++ b/.changeset/clawsl-change.md
@@ -1,0 +1,5 @@
+---
+"sst":minor
+---
+
+arm64 docker build support for Python functions

--- a/packages/sst/src/runtime/handlers/python.ts
+++ b/packages/sst/src/runtime/handlers/python.ts
@@ -105,6 +105,7 @@ export const usePythonHandler = Context.memo(async () => {
         installCommands: input.props.python?.installCommands,
         entry: src,
         runtime: RUNTIME_MAP[input.props.runtime!],
+        architecture: input.props.architecture,
         outputPathSuffix: ".",
         out: input.out,
       });

--- a/packages/sst/src/runtime/handlers/pythonBundling.ts
+++ b/packages/sst/src/runtime/handlers/pythonBundling.ts
@@ -5,6 +5,8 @@ import fs from "fs";
 import url from "url";
 import path from "path";
 import { Runtime } from "aws-cdk-lib/aws-lambda";
+import { FunctionProps } from "../../constructs/Function.js";
+
 import { AssetHashType, DockerImage, FileSystem } from "aws-cdk-lib/core";
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 
@@ -31,6 +33,11 @@ export interface BundlingOptions {
    * The runtime of the lambda function
    */
   readonly runtime: Runtime;
+
+  /**
+   * Architecture used by the lambda function
+   */
+  readonly architecture: FunctionProps["architecture"];
 
   /**
    * Output path suffix ('python' for a layer, '.' otherwise)
@@ -84,7 +91,7 @@ export interface BundlingOptions {
  * Produce bundled Lambda asset code
  */
 export function bundle(options: BundlingOptions & { out: string }) {
-  const { entry, runtime, outputPathSuffix, installCommands } = options;
+  const { entry, runtime, architecture, outputPathSuffix, installCommands } = options;
 
   const stagedir = FileSystem.mkdtemp("python-bundling-");
   const hasDeps = stageDependencies(entry, stagedir);
@@ -111,7 +118,10 @@ export function bundle(options: BundlingOptions & { out: string }) {
 
   const image = DockerImage.fromBuild(stagedir, {
     buildArgs: {
-      IMAGE: runtime.bundlingImage.image,
+      IMAGE:
+        runtime.bundlingImage.image +
+        // the default x86_64 doesn't need to be set explicitly
+        (architecture == "arm_64" ? ":latest-arm64" : "")
     },
     file: dockerfile,
   });


### PR DESCRIPTION
This adds support for using the arm64 docker image to compile python dependencies and fixes the issue [described here](https://discordapp.com/channels/983865673656705025/1120466923411476512) 