### PR TITLE
Fix/use stack name for migration function

### DIFF
--- a/.changeset/wicked-mice-tell.md
+++ b/.changeset/wicked-mice-tell.md
@@ -1,0 +1,5 @@
+---
+"sst": minor
+---
+
+fix: use stackName in migrator metadata instead of stack id

--- a/packages/sst/src/constructs/Construct.ts
+++ b/packages/sst/src/constructs/Construct.ts
@@ -27,7 +27,7 @@ export function getFunctionRef(fn?: any) {
   if (!(fn instanceof Fn)) return undefined;
   return {
     node: fn.node.addr,
-    stack: Stack.of(fn).node.id,
+    stack: Stack.of(fn).stackName,
   };
 }
 


### PR DESCRIPTION
If you set `stackName` for a stack, accessing the Migrations button in the RDS console will fail as it always uses `stack.node.id`, instead of `stack.stackName`, and you get a blank screen due to a javascript error.

This is the output you get with `node.id`:

```json
{
    "id": "Database",
    "addr": "c83e86d028cf83862aee290d8d85c85d3117212611",
    "stack": "sst-rds-serverless-v1-cluster-dev",
    "type": "RDS",
    "data": {
        "engine": "postgresql11.13",
        "secretArn": "arn:aws:secretsmanager:ap-southeast-2:257611358457:secret:sst-rds-root-dev-PCAaxm",
        "types": {
            "path": "src/sql.generated.ts"
        },
        "clusterArn": "arn:aws:rds:ap-southeast-2:257611358457:cluster:sst-rds-dev",
        "clusterIdentifier": "sst-rds-dev",
        "defaultDatabaseName": "acme",
        "migrator": {
            "node": "c8ae68579236cf6a69afe23f1e2a20f1cca5bf6916",
            "stack": "dev-sst-rds-MyStack"
        }
    }
}
```

As you can see the stack name has changed, but the migrator still returns node.id.