### PR TITLE
feat: enforce ssl connections to S3 to stop triggering S3.5 of the AWS Foundational Security Best Practices

### DIFF
--- a/.changeset/serious-paws-jam.md
+++ b/.changeset/serious-paws-jam.md
@@ -1,0 +1,5 @@
+---
+"sst": minor
+---
+
+enforce ssl connections to S3 to stop triggering S3.5 of the AWS Foundational Security Best Practices

--- a/packages/sst/src/bootstrap.ts
+++ b/packages/sst/src/bootstrap.ts
@@ -190,6 +190,7 @@ export async function bootstrapSST() {
     encryption: BucketEncryption.S3_MANAGED,
     removalPolicy: RemovalPolicy.DESTROY,
     autoDeleteObjects: true,
+    enforceSSL: true,
     blockPublicAccess:
       cdk?.publicAccessBlockConfiguration !== false
         ? BlockPublicAccess.BLOCK_ALL


### PR DESCRIPTION
The bootstrap stack triggers various alarms for folks using Security Hub. This address S3.5. In case you're not using Security Hub (really an enterprise thing), see screenshot here. This wakes up the security department and they start to ask questions about SST.

![image](https://github.com/serverless-stack/sst/assets/1514612/c0b14bd2-3a3b-4d23-bb25-f1d1aaea838e)
