### PR TITLE
[NextjsSite] Add revalidation.vpc prop

### DIFF
--- a/www/docs/constructs/NextjsSite.about.md
+++ b/www/docs/constructs/NextjsSite.about.md
@@ -379,6 +379,22 @@ new NextjsSite(stack, "Site", {
 });
 ```
 
+### Configuring revalidation function
+
+```js {8-10}
+const vpc = Vpc.fromVpcAttributes(stack, 'FrontendVpc', {
+    vpcId: 'vpc-01123456789abcdef0',
+    availabilityZones: ['us-east-1a', 'us-east-1b'],
+});
+
+new NextjsSite(stack, "Site", {
+  path: "my-next-app/",
+  revalidation: {
+    vpc,
+  },
+});
+```
+
 ### Advanced examples
 
 #### Configuring VPC


### PR DESCRIPTION
This PR enables the developer to configure the VPC of the revalidation function.

Solves https://github.com/serverless-stack/sst/issues/3016

This code is inspired by the `cdk.server` prop that applies configuration to the server function. For the moment, only `vpc` and `vpcSubnets` can be configured, which is enough to solve the issue.