### PR TITLE
feat: enforce S3 https connections

### DIFF
--- a/.changeset/angry-waves-marry.md
+++ b/.changeset/angry-waves-marry.md
@@ -1,5 +1,5 @@
 ---
-"sst": minor
+"sst": patch
 ---
 
-feat: enforce S3 https connections
+Bucket: enforce S3 https connections

--- a/.changeset/angry-waves-marry.md
+++ b/.changeset/angry-waves-marry.md
@@ -1,0 +1,5 @@
+---
+"sst": minor
+---
+
+feat: enforce S3 https connections

--- a/packages/sst/src/constructs/Bucket.ts
+++ b/packages/sst/src/constructs/Bucket.ts
@@ -504,7 +504,7 @@ export class Bucket extends Construct implements SSTConstruct {
         cors: this.buildCorsConfig(cors),
         blockPublicAccess: this.buildBlockPublicAccessConfig(blockPublicACLs),
         objectOwnership: this.buildObjectOwnershipConfig(blockPublicACLs),
-	enforceSSL: true,
+        enforceSSL: true,
         ...cdk?.bucket,
       });
     }

--- a/packages/sst/src/constructs/Bucket.ts
+++ b/packages/sst/src/constructs/Bucket.ts
@@ -504,6 +504,7 @@ export class Bucket extends Construct implements SSTConstruct {
         cors: this.buildCorsConfig(cors),
         blockPublicAccess: this.buildBlockPublicAccessConfig(blockPublicACLs),
         objectOwnership: this.buildObjectOwnershipConfig(blockPublicACLs),
+	enforceSSL: true,
         ...cdk?.bucket,
       });
     }

--- a/packages/sst/test/constructs/Bucket.test.ts
+++ b/packages/sst/test/constructs/Bucket.test.ts
@@ -18,6 +18,29 @@ const lambdaDefaultPolicy = {
   Resource: "*",
 };
 
+test("default: https enforced", async () => {
+  const stack = new Stack(await createApp(), "stack");
+  new Bucket(stack, "Bucket");
+  hasResource(stack, "AWS::S3::BucketPolicy", {
+    Bucket: {
+      Ref: "BucketD7FEB781",
+    },
+    PolicyDocument: {
+      Statement: [
+        {
+          Action: "s3:*",
+          Condition: {
+            Bool: {
+              "aws:SecureTransport": "false",
+            },
+          },
+          Effect: "Deny",
+        },
+      ],
+    },
+  });
+});
+
 test("cdk.id: undefined", async () => {
   const stack = new Stack(await createApp(), "stack");
   new Bucket(stack, "Bucket");
@@ -223,29 +246,6 @@ test("blockPublicACLs: false", async () => {
       Rules: [
         {
           ObjectOwnership: "BucketOwnerPreferred",
-        },
-      ],
-    },
-  });
-});
-
-test("https enforced", async () => {
-  const stack = new Stack(await createApp(), "stack");
-  new Bucket(stack, "Bucket");
-  hasResource(stack, "AWS::S3::BucketPolicy", {
-    Bucket: {
-      Ref: "BucketD7FEB781",
-    },
-    PolicyDocument: {
-      Statement: [
-        {
-          Action: "s3:*",
-          Condition: {
-            Bool: {
-              "aws:SecureTransport": "false",
-            },
-          },
-          Effect: "Deny",
         },
       ],
     },

--- a/packages/sst/test/constructs/Bucket.test.ts
+++ b/packages/sst/test/constructs/Bucket.test.ts
@@ -229,6 +229,29 @@ test("blockPublicACLs: false", async () => {
   });
 });
 
+test("https enforced", async () => {
+  const stack = new Stack(await createApp(), "stack");
+  new Bucket(stack, "Bucket");
+  hasResource(stack, "AWS::S3::BucketPolicy", {
+    Bucket: {
+      Ref: "BucketD7FEB781",
+    },
+    PolicyDocument: {
+      Statement: [
+        {
+          Action: "s3:*",
+          Condition: {
+            Bool: {
+              "aws:SecureTransport": "false",
+            },
+          },
+          Effect: "Deny",
+        },
+      ],
+    },
+  });
+});
+
 /////////////////////////////
 // Test notifications
 /////////////////////////////


### PR DESCRIPTION
Similar to #3015 but now enforced for every bucket. This to start stopping SST buckets showing up in AWS Security Hub.