### PR TITLE
feat: add a single lifecyle rule to stop triggering rule S3.13 in Security Hub

### DIFF
--- a/.changeset/two-kings-invent.md
+++ b/.changeset/two-kings-invent.md
@@ -1,0 +1,5 @@
+---
+"sst": minor
+---
+
+feat: add a single lifecyle rule to stop triggering rule S3.13 in Security Hub

--- a/packages/sst/src/bootstrap.ts
+++ b/packages/sst/src/bootstrap.ts
@@ -9,6 +9,7 @@ import {
 import {
   App,
   DefaultStackSynthesizer,
+  Duration,
   CfnOutput,
   Tags,
   Stack,
@@ -208,6 +209,11 @@ export async function bootstrapSST() {
     removalPolicy: RemovalPolicy.DESTROY,
     autoDeleteObjects: true,
     enforceSSL: true,
+    lifecycleRules: [{
+      id: "Remove partial uploads after 3 days",
+      enabled: true,
+      abortIncompleteMultipartUploadAfter: Duration.days(3),
+    }],
     blockPublicAccess:
       cdk?.publicAccessBlockConfiguration !== false
         ? BlockPublicAccess.BLOCK_ALL


### PR DESCRIPTION
This is a low level warning generated when enabling AWS Foundational Security Best Practices v1.0.0 in Security Hub. This is a very common one to enable. Just adding an almost empty life-cycle rule will stop this warning.

It might be good to also add a rule to transition old objects to glacier, or remove them altogether.

For those who don't have all these enterprise features enabled, this is the screenshot of the alarm:

![image](https://github.com/serverless-stack/sst/assets/1514612/8b27bce0-24a8-4ec4-806b-2bd433902c84)
