### PR TITLE
Fix examples/api-sst-auth-google

### DIFF
--- a/examples/api-sst-auth-google/package.json
+++ b/examples/api-sst-auth-google/package.json
@@ -13,8 +13,8 @@
   },
   "devDependencies": {
     "sst": "^2.13.9",
-    "aws-cdk-lib": "2.79.1",
-    "constructs": "10.1.156",
+    "aws-cdk-lib": "2.85.0",
+    "constructs": "10.2.61",
     "typescript": "^5.1.3",
     "@tsconfig/node16": "^1.0.4"
   },

--- a/examples/api-sst-auth-google/packages/functions/src/auth.ts
+++ b/examples/api-sst-auth-google/packages/functions/src/auth.ts
@@ -1,6 +1,6 @@
 import { Session, AuthHandler, GoogleAdapter } from "sst/node/auth";
 import { Table } from "sst/node/table";
-import { ViteStaticSite } from "sst/node/site";
+import { StaticSite } from "sst/node/site";
 import { DynamoDBClient, PutItemCommand } from "@aws-sdk/client-dynamodb";
 import { marshall } from "@aws-sdk/util-dynamodb";
 
@@ -37,7 +37,7 @@ export const handler = AuthHandler({
         );
 
         return Session.parameter({
-          redirect: ViteStaticSite.site.url || "http://127.0.0.1:5173",
+          redirect: StaticSite.site.url || "http://127.0.0.1:5173",
           type: "user",
           properties: {
             userID: claims.sub,

--- a/examples/api-sst-auth-google/sst.config.ts
+++ b/examples/api-sst-auth-google/sst.config.ts
@@ -1,4 +1,4 @@
-import { SSTConfig } from "sst";
+import type { SSTConfig } from "sst";
 import { ExampleStack } from "./stacks/ExampleStack";
 
 export default {

--- a/examples/api-sst-auth-google/stacks/ExampleStack.ts
+++ b/examples/api-sst-auth-google/stacks/ExampleStack.ts
@@ -1,4 +1,4 @@
-import { StackContext, Api, Auth, ViteStaticSite, Table } from "sst/constructs";
+import { StackContext, Api, Auth, StaticSite, Table } from "sst/constructs";
 
 export function ExampleStack({ stack }: StackContext) {
   // Create a database Table
@@ -17,14 +17,16 @@ export function ExampleStack({ stack }: StackContext) {
       },
     },
     routes: {
-      "GET /": "packages/functions/src/lambda.handler",
+      "GET /": "packages/functions/src/auth.handler",
       "GET /session": "packages/functions/src/session.handler",
     },
   });
 
   // Create a React site
-  const site = new ViteStaticSite(stack, "site", {
+  const site = new StaticSite(stack, "site", {
     path: "web",
+    buildCommand: "npm run build",
+    buildOutput: "dist",
     environment: {
       VITE_APP_API_URL: api.url,
     },


### PR DESCRIPTION
- Correct use of ViteStaticSite
- Correct name of auth.handler
- Import SSTConfig as type 
- Update aws-cdk-lib and constructs 