### PR TITLE
feat: support java17 as runtime option

### DIFF
--- a/.changeset/thin-coats-approve.md
+++ b/.changeset/thin-coats-approve.md
@@ -1,0 +1,7 @@
+---
+"create-sst": minor
+"sst": minor
+"@serverless-stack/docs": minor
+---
+
+add java17 as a supported runtime for Java functions

--- a/.changeset/thin-coats-approve.md
+++ b/.changeset/thin-coats-approve.md
@@ -1,7 +1,7 @@
 ---
-"create-sst": minor
-"sst": minor
-"@serverless-stack/docs": minor
+"create-sst": patch
+"sst": patch
+"@serverless-stack/docs": patch
 ---
 
-add java17 as a supported runtime for Java functions
+Function: support java17 runtime

--- a/packages/create-sst/bin/presets/other/java/templates/sst.config.ts
+++ b/packages/create-sst/bin/presets/other/java/templates/sst.config.ts
@@ -10,7 +10,7 @@ export default {
   },
   stacks(app) {
     app.setDefaultFunctionProps({
-      runtime: "java11",
+      runtime: "java17",
     });
     app.stack(function Stack({ stack }) {
       const api = new Api(stack, "api", {

--- a/packages/sst/src/constructs/Function.ts
+++ b/packages/sst/src/constructs/Function.ts
@@ -75,6 +75,7 @@ const supportedRuntimes = {
   dotnet6: CDKRuntime.DOTNET_6,
   java8: CDKRuntime.JAVA_8,
   java11: CDKRuntime.JAVA_11,
+  java17: CDKRuntime.JAVA_17,
   "go1.x": CDKRuntime.PROVIDED_AL2,
   go: CDKRuntime.PROVIDED_AL2,
 };

--- a/www/docs/constructs/Function.about.md
+++ b/www/docs/constructs/Function.about.md
@@ -229,7 +229,7 @@ new Function(stack, "MyLambda", {
     buildOutputDir: "output",
   },
   handler: "example.Handler::handleRequest",
-  runtime: "java11",
+  runtime: "java17",
 });
 ```
 


### PR DESCRIPTION
This is similar to #2870 but that PR is a bit obsolete as it included a no longer necessary update to the CDK version.

We need Java17 as this is the out of the box supported version of CodeBuild for the STANDARD_7_0 image. And the version that supports node 18. So if you want to mix both (we do), you need Java 17.