### PR TITLE
Remove deprecated rds engine

### DIFF
--- a/.changeset/dirty-bugs-hug.md
+++ b/.changeset/dirty-bugs-hug.md
@@ -1,0 +1,6 @@
+---
+"sst": patch
+"@serverless-stack/docs": patch
+---
+
+Remove deprecated rds engine

--- a/packages/sst/src/constructs/RDS.ts
+++ b/packages/sst/src/constructs/RDS.ts
@@ -45,7 +45,6 @@ export interface RDSProps {
   engine:
     | "mysql5.6"
     | "mysql5.7"
-    | "postgresql10.14"
     | "postgresql11.13"
     | "postgresql11.16"
     | "postgresql13.9";
@@ -423,10 +422,6 @@ export class RDS extends Construct implements SSTConstruct {
     } else if (engine === "mysql5.7") {
       return DatabaseClusterEngine.auroraMysql({
         version: AuroraMysqlEngineVersion.VER_2_07_1,
-      });
-    } else if (engine === "postgresql10.14") {
-      return DatabaseClusterEngine.auroraPostgres({
-        version: AuroraPostgresEngineVersion.VER_10_14,
       });
     } else if (engine === "postgresql11.13") {
       return DatabaseClusterEngine.auroraPostgres({

--- a/www/docs/constructs/v0/RDS.md
+++ b/www/docs/constructs/v0/RDS.md
@@ -33,7 +33,7 @@ _Parameters_
 import { RDS } from "@serverless-stack/resources";
 
 new RDS(this, "Database", {
-  engine: "postgresql10.14",
+  engine: "postgresql13.9",
   defaultDatabaseName: "my_database",
 });
 ```
@@ -62,7 +62,7 @@ const devConfig = {
 };
 
 new RDS(this, "Database", {
-  engine: "postgresql10.14",
+  engine: "postgresql13.9",
   defaultDatabaseName: "acme",
   scaling: app.stage === "prod" ? prodConfig : devConfig,
 });
@@ -74,7 +74,7 @@ new RDS(this, "Database", {
 
 ```js
 new RDS(this, "Database", {
-  engine: "postgresql10.14",
+  engine: "postgresql13.9",
   defaultDatabaseName: "acme",
   migrations: "path/to/migration/scripts",
 });
@@ -156,7 +156,7 @@ You can configure the internally created CDK `ServerlessCluster` instance.
 import * as cdk from "aws-cdk-lib";
 
 new RDS(this, "Database", {
-  engine: "postgresql10.14",
+  engine: "postgresql13.9",
   defaultDatabaseName: "acme",
   rdsServerlessCluster: {
     backupRetention: cdk.Duration.days(7),
@@ -178,7 +178,7 @@ You can override the internally created `VPC` instance.
 import * as ec2 from "aws-cdk-lib/aws-ec2";
 
 new RDS(this, "Database", {
-  engine: "postgresql10.14",
+  engine: "postgresql13.9",
   defaultDatabaseName: "acme",
   rdsServerlessCluster: {  
     vpc: ec2.Vpc.fromLookup(this, "VPC", {
@@ -237,7 +237,7 @@ The internally created CDK `ServerlessCluster` instance.
 
 _Type_ : `string`
 
-Supported engine are `mysql5.6`, `mysql5.7`, and `postgresql10.14` and `postgresql11.13`.
+Supported engine are `mysql5.6`, `mysql5.7`, `postgresql11.13`, `postgresql11.16` and `postgresql13.9`
 
 ### defaultDatabaseName
 

--- a/www/docs/constructs/v1/RDS.tsdoc.md
+++ b/www/docs/constructs/v1/RDS.tsdoc.md
@@ -25,7 +25,7 @@ Name of a database which is automatically created inside the cluster.
 
 ### engine
 
-_Type_ : <span class='mono'><span class="mono">"mysql5.6"</span> | <span class="mono">"mysql5.7"</span> | <span class="mono">"postgresql10.14"</span> | <span class="mono">"postgresql11.13"</span></span>
+_Type_ : <span class='mono'><span class="mono">"mysql5.6"</span> | <span class="mono">"mysql5.7"</span> | <span class="mono">"postgresql11.13"</span> | <span class="mono">"postgresql11.16"</span> | <span class="mono">"postgresql13.19"</span></span>
 
 Database engine of the cluster. Cannot be changed once set.
 


### PR DESCRIPTION
`postgresql10.14` has been deprecated by aws and therefore when building with this engine an exception occurs:

`Db dbCluster/Cluster AWS::RDS::DBCluster CREATE_FAILED Resource handler returned message: "The engine mode serverless you requested is currently unavailable. (Service: Rds, Status Code: 400, Request ID: x)" (RequestToken: x, HandlerErrorCode: InvalidRequest)`


- [link to discord discussion](https://discord.com/channels/983865673656705025/1121721945516429344/1121721945516429344)
- [Link to aws announcement](https://repost.aws/questions/QU0ligxMlJSJWhzzgKbKgytQ/questions/QU0ligxMlJSJWhzzgKbKgytQ/announcement-amazon-aurora-postgresql-10-x-end-of-support-is-january-31-2023)