### PR TITLE
fix: add s3 key prefix to versioned sub dir

### DIFF
--- a/.changeset/silver-fishes-draw.md
+++ b/.changeset/silver-fishes-draw.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+SsrSite: fix s3 assets not setting cache-control

--- a/packages/sst/src/constructs/SsrSite.ts
+++ b/packages/sst/src/constructs/SsrSite.ts
@@ -699,7 +699,7 @@ export abstract class SsrSite extends Construct implements SSTConstruct {
       if (item === this.buildConfig.clientBuildVersionedSubDir) {
         fileOptions.push({
           exclude: "*",
-          include: `${this.buildConfig.clientBuildVersionedSubDir}/*`,
+          include: path.posix.join(this.buildConfig.clientBuildS3KeyPrefix ?? "", this.buildConfig.clientBuildVersionedSubDir, "*"),
           cacheControl: "public,max-age=31536000,immutable",
         });
       }

--- a/packages/sst/src/constructs/SsrSite.ts
+++ b/packages/sst/src/constructs/SsrSite.ts
@@ -699,7 +699,11 @@ export abstract class SsrSite extends Construct implements SSTConstruct {
       if (item === this.buildConfig.clientBuildVersionedSubDir) {
         fileOptions.push({
           exclude: "*",
-          include: path.posix.join(this.buildConfig.clientBuildS3KeyPrefix ?? "", this.buildConfig.clientBuildVersionedSubDir, "*"),
+          include: path.posix.join(
+            this.buildConfig.clientBuildS3KeyPrefix ?? "",
+            this.buildConfig.clientBuildVersionedSubDir,
+            "*"
+          ),
           cacheControl: "public,max-age=31536000,immutable",
         });
       }


### PR DESCRIPTION
fixes: #3042

The initial PR only fixed the unversioned files.