### PR TITLE
SST / NodeJS runtime: await for fs.writeFile

### DIFF
--- a/.changeset/ten-socks-build.md
+++ b/.changeset/ten-socks-build.md
@@ -2,4 +2,4 @@
 "sst": patch
 ---
 
-SST / NodeJS runtime: await for fs.writeFile
+Function: await fs.writeFile for nodejs runtime

--- a/.changeset/ten-socks-build.md
+++ b/.changeset/ten-socks-build.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+SST / NodeJS runtime: await for fs.writeFile

--- a/packages/sst/src/runtime/handlers/node.ts
+++ b/packages/sst/src/runtime/handlers/node.ts
@@ -213,7 +213,7 @@ export const useNodeHandler = Context.memo(async () => {
               .readFile(path.join(src, "package.json"))
               .then((x) => x.toString())
           );
-          fs.writeFile(
+          await fs.writeFile(
             path.join(input.out, "package.json"),
             JSON.stringify({
               dependencies: Object.fromEntries(


### PR DESCRIPTION
It seems there is a missing await for fs.writeFile
This causes issues on our runners:
Error: Failed to build function ".build/handler.main"
Error: Command failed: npm install
npm ERR! code EJSONPARSE
npm ERR! path /home/ubuntu/actions-runner/_work/project-name/project-name/.sst/artifacts/c8f5e1b156ab358204912997ac001c6caa658f1734/package.json
npm ERR! JSON.parse Unexpected end of JSON input while parsing empty string
npm ERR! JSON.parse Failed to parse JSON data.
npm ERR! JSON.parse Note: package.json must be actual JSON, not just JavaScript.


The issue happens truly randomly, but in most cases it fails. After failing execution we can see valid json in package.json file.
