### PR TITLE
Fix: typo on docs

### DIFF
--- a/www/docs/constructs/Stack.about.md
+++ b/www/docs/constructs/Stack.about.md
@@ -108,7 +108,7 @@ Simple add an `async` modifier to your function definition
 import { StackContext } from "sst/constructs";
 
 export async function MyStack({ stack }: StackContext) {
-  const foo = await someAsynCall();
+  const foo = await someAsyncCall();
   // Define stack
 }
 ```

--- a/www/docs/constructs/v1/Stack.about.md
+++ b/www/docs/constructs/v1/Stack.about.md
@@ -105,7 +105,7 @@ Simple add an `async` modifier to your function definition
 import { StackContext } from "@serverless-stack/resources"
 
 export async function MyStack({ stack }: StackContext) {
-  const foo = await someAsynCall();
+  const foo = await someAsyncCall();
   // Define stack
 }
 ```


### PR DESCRIPTION
fixes typo on the word `async`