### PR TITLE
documentation: Correction to auth documentation

### DIFF
--- a/www/docs/constructs/v1/Auth.tsdoc.md
+++ b/www/docs/constructs/v1/Auth.tsdoc.md
@@ -73,7 +73,7 @@ The API to attach auth routes to
 
 
 ```js
-const api = new Auth(stack, "Api", {});
+const api = new Api(stack, "Api", {});
 const auth = new Auth(stack, "Auth", {
   authenticator: "functions/authenticator.handler"
 })
@@ -92,7 +92,7 @@ Optionally specify the prefix to mount authentication routes
 
 
 ```js
-const api = new Auth(stack, "Api", {});
+const api = new Api(stack, "Api", {});
 const auth = new Auth(stack, "Auth", {
   authenticator: "functions/authenticator.handler"
 })


### PR DESCRIPTION
Code examples previously showed the `Auth` object wrapping another `Auth` object which is confusing to read. This corrects the docs to show the correct `API` object type.