### PR TITLE
fix: remove duplicate S3 origins for static assets

### DIFF
--- a/.changeset/dull-papayas-laugh.md
+++ b/.changeset/dull-papayas-laugh.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+NextjsSite: update OpenNext 2.0.4

--- a/.changeset/polite-dogs-beg.md
+++ b/.changeset/polite-dogs-beg.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+SsrSite: fix multiple s3 origins created for static assets

--- a/packages/sst/src/constructs/NextjsSite.ts
+++ b/packages/sst/src/constructs/NextjsSite.ts
@@ -27,7 +27,7 @@ import {
   CachePolicy,
   ICachePolicy,
 } from "aws-cdk-lib/aws-cloudfront";
-import { S3Origin, HttpOrigin } from "aws-cdk-lib/aws-cloudfront-origins";
+import { HttpOrigin } from "aws-cdk-lib/aws-cloudfront-origins";
 import { Rule, Schedule } from "aws-cdk-lib/aws-events";
 import { LambdaFunction } from "aws-cdk-lib/aws-events-targets";
 import { Queue } from "aws-cdk-lib/aws-sqs";
@@ -85,7 +85,7 @@ export class NextjsSite extends SsrSite {
 
   constructor(scope: Construct, id: string, props?: NextjsSiteProps) {
     super(scope, id, {
-      buildCommand: "npx --yes open-next@2.0.3 build",
+      buildCommand: "npx --yes open-next@2.0.4 build",
       ...props,
     });
 
@@ -375,9 +375,6 @@ export class NextjsSite extends SsrSite {
   protected createCloudFrontDistributionForEdge(): Distribution {
     const { cdk } = this.props;
     const cfDistributionProps = cdk?.distribution || {};
-    const s3Origin = new S3Origin(this.cdk!.bucket, {
-      originPath: "/" + this.buildConfig.clientBuildS3KeyPrefix,
-    });
     const cachePolicy =
       cdk?.serverCachePolicy ??
       this.buildServerCachePolicy([
@@ -386,10 +383,7 @@ export class NextjsSite extends SsrSite {
         "next-router-prefetch",
         "next-router-state-tree",
       ]);
-    const serverBehavior = this.buildDefaultBehaviorForEdge(
-      s3Origin,
-      cachePolicy
-    );
+    const serverBehavior = this.buildDefaultBehaviorForEdge(cachePolicy);
 
     return new Distribution(this, "Distribution", {
       // these values can be overwritten by cfDistributionProps

--- a/packages/sst/src/constructs/SsrSite.ts
+++ b/packages/sst/src/constructs/SsrSite.ts
@@ -1050,13 +1050,19 @@ function handler(event) {
       this.props.path,
       this.buildConfig.clientBuildOutputDir
     );
-    for (const item of fs.readdirSync(publicDir)) {
+    const items = fs.readdirSync(publicDir)
+    if (!items.length) {
+      return
+    }
+
+    const s3Origin = new S3Origin(this.bucket, {
+      originPath: "/" + (this.buildConfig.clientBuildS3KeyPrefix ?? ""),
+    })
+    for (const item of items) {
       const isDir = fs.statSync(path.join(publicDir, item)).isDirectory();
       this.distribution.addBehavior(
         isDir ? `${item}/*` : item,
-        new S3Origin(this.bucket, {
-          originPath: "/" + (this.buildConfig.clientBuildS3KeyPrefix ?? ""),
-        }),
+        s3Origin,
         {
           viewerProtocolPolicy: ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
           allowedMethods: AllowedMethods.ALLOW_GET_HEAD_OPTIONS,


### PR DESCRIPTION
The SsrSite distribution for static files in `/public` was creating a new S3Origin for each item.