### PR TITLE
feat: added fileOptions to SsrSite

### DIFF
--- a/.changeset/fluffy-birds-switch.md
+++ b/.changeset/fluffy-birds-switch.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+SsrSite: support `fileOptions` props

--- a/packages/sst/src/constructs/BaseSite.ts
+++ b/packages/sst/src/constructs/BaseSite.ts
@@ -8,6 +8,13 @@ import {
 } from "aws-cdk-lib/aws-cloudfront";
 import { ICertificate } from "aws-cdk-lib/aws-certificatemanager";
 
+export interface BaseSiteFileOptions {
+  exclude: string | string[];
+  include: string | string[];
+  cacheControl: string;
+  contentType?: string;
+}
+
 /**
  * The customDomain for this website. SST supports domains that are hosted either on [Route 53](https://aws.amazon.com/route53/) or externally.
  *

--- a/packages/sst/src/constructs/StaticSite.ts
+++ b/packages/sst/src/constructs/StaticSite.ts
@@ -44,6 +44,7 @@ import { App } from "./App.js";
 import { Stack } from "./Stack.js";
 import {
   BaseSiteDomainProps,
+  BaseSiteFileOptions,
   BaseSiteReplaceProps,
   BaseSiteCdkDistributionProps,
   getBuildCmdEnvironment,
@@ -62,13 +63,6 @@ import { gray } from "colorette";
 import { useProject } from "../project.js";
 
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
-
-export interface StaticSiteFileOptions {
-  exclude: string | string[];
-  include: string | string[];
-  cacheControl: string;
-  contentType?: string;
-}
 
 export interface StaticSiteProps {
   /**
@@ -135,7 +129,7 @@ export interface StaticSiteProps {
   /**
    * Pass in a list of file options to configure cache control for different files. Behind the scenes, the `StaticSite` construct uses a combination of the `s3 cp` and `s3 sync` commands to upload the website content to the S3 bucket. An `s3 cp` command is run for each file option block, and the options are passed in as the command options.
    *
-   * Defaults to no cache control for HTML files, and a 1 year cache control for JS/CSS files.
+   * @default No cache control for HTML files, and a 1 year cache control for JS/CSS files.
    * ```js
    * [
    *   {
@@ -332,6 +326,7 @@ export interface StaticSiteProps {
 }
 
 export interface StaticSiteDomainProps extends BaseSiteDomainProps {}
+export interface StaticSiteFileOptions extends BaseSiteFileOptions {}
 export interface StaticSiteReplaceProps extends BaseSiteReplaceProps {}
 export interface StaticSiteCdkDistributionProps
   extends BaseSiteCdkDistributionProps {}


### PR DESCRIPTION
Adding `fileOptions` to `SsrSite` will allow users to customize cache control and content type headers for static assets, much like `StaticSite`.

Discussion:
https://discord.com/channels/983865673656705025/1124926722740080651/1124926722740080651