### PR TITLE
feat: Adds container props to Function construct

### DIFF
--- a/packages/sst/src/constructs/Function.ts
+++ b/packages/sst/src/constructs/Function.ts
@@ -31,6 +31,7 @@ import { useWarning } from "./util/warning.js";
 import {
   Architecture,
   AssetCode,
+  AssetImageCodeProps,
   CfnFunction,
   Code,
   Function as CDKFunction,
@@ -142,9 +143,9 @@ export interface FunctionProps
   python?: PythonProps;
 
   /**
-   * Used to configure image function properties
+   * Used to configure container function properties
    */
-  //image?: ImageProps;
+  container?: ContainerProps;
 
   /**
    * Hooks to run before and after function builds
@@ -534,6 +535,23 @@ export interface PythonProps {
   installCommands?: string[];
 }
 
+export interface ContainerProps extends AssetImageCodeProps {
+  /** 
+   * Extends AssetImageCodeProps to allow container implementations to specify additional properties.
+   * ```js
+  * new Function(stack, "Function", {
+  *   container: {
+  *     cmd: ['python3'],
+  *     buildArgs: {
+  *         ARG1 : "ARG"
+  *     }
+  * 
+  *   }
+  * })
+  * ```
+*/
+}
+
 /**
  * Used to configure Java package build options
  */
@@ -720,7 +738,7 @@ export class Function extends CDKFunction implements SSTConstruct {
                 path.resolve(__dirname, "../support/bridge"),
                 {
                   ...(architecture?.dockerPlatform
-                    ? { platform: Platform.custom(architecture.dockerPlatform) }
+                    ? { platform: Platform.custom(architecture.dockerPlatform), ...props.container }
                     : {}),
                 }
               ),
@@ -775,7 +793,7 @@ export class Function extends CDKFunction implements SSTConstruct {
           ? {
               code: Code.fromAssetImage(props.handler!, {
                 ...(architecture?.dockerPlatform
-                  ? { platform: Platform.custom(architecture.dockerPlatform) }
+                  ? { platform: Platform.custom(architecture.dockerPlatform), ...props.container }
                   : {}),
               }),
               handler: CDKHandler.FROM_IMAGE,

--- a/packages/sst/test/constructs/Function.test.ts
+++ b/packages/sst/test/constructs/Function.test.ts
@@ -244,6 +244,27 @@ test("runtime: container", async () => {
   });
 });
 
+test("runtime: container with props", async () => {
+  const app = await createApp();
+  const stack = new Stack(app, "stack");
+  new Function(stack, "Function", {
+    runtime: "container",
+    handler: "test/constructs/container-function",
+    container: {
+      cmd: ['python3']
+    }
+  });
+  await app.finish();
+  hasResource(stack, "AWS::Lambda::Function", {
+    Code: objectLike({
+      ImageUri: ANY,
+    }),
+    ImageConfig: objectLike({Command : ["python3"]})
+  });
+});
+
+
+
 test("runtime: invalid", async () => {
   const app = await createApp();
   const stack = new Stack(app, "stack");


### PR DESCRIPTION
## Problem Statement 
When using the new Function construct support for containers, it seemed like there were a few gaps. The underlying props weren't previously exposed. For example, if you wanted to use one container for many different functions, when using CDK you could pass in CMD or Entrypoint overrides. In the latest release, that functionality did not exist.

## Proposal
Further extend this functionality, to support `AssetImageCodeProps`.

## Implementation
I took the approach that is used for `PythonProps`, `JavaProps`, etc. I have added `ContainerProps` which is just an extension of the `AssetImageCodeProps` Interface. So when using this, it looks like the following: 

```javascript
new sst.Function(this, "sample", { 
  runtime: "container",
  handler: "path/to/dockerfile",
  container: {
    cmd: ["cmdOverride"],
    entrypoint: ["entrypointOverride"]
    }
});
```


## Changes
packages/sst/src/constructs/Function.ts
packages/sst/tests/Function.test.ts