### PR TITLE
Output build errors in Rust runtime

### DIFF
--- a/.changeset/chatty-carpets-pull.md
+++ b/.changeset/chatty-carpets-pull.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+Function/rust: display build errors

--- a/packages/sst/src/runtime/handlers/rust.ts
+++ b/packages/sst/src/runtime/handlers/rust.ts
@@ -78,6 +78,7 @@ export const useRustHandler = Context.memo(async () => {
             path.join(input.out, "handler")
           );
         } catch (ex) {
+          consile.log(ex);
           throw new VisibleError("Failed to build");
         }
       }
@@ -95,6 +96,7 @@ export const useRustHandler = Context.memo(async () => {
             path.join(input.out, "bootstrap")
           );
         } catch (ex) {
+          consile.log(ex);
           throw new VisibleError("Failed to build");
         }
       }

--- a/packages/sst/src/runtime/handlers/rust.ts
+++ b/packages/sst/src/runtime/handlers/rust.ts
@@ -78,7 +78,7 @@ export const useRustHandler = Context.memo(async () => {
             path.join(input.out, "handler")
           );
         } catch (ex) {
-          consile.log(ex);
+          console.log(ex);
           throw new VisibleError("Failed to build");
         }
       }
@@ -96,7 +96,7 @@ export const useRustHandler = Context.memo(async () => {
             path.join(input.out, "bootstrap")
           );
         } catch (ex) {
-          consile.log(ex);
+          console.log(ex);
           throw new VisibleError("Failed to build");
         }
       }

--- a/packages/sst/src/runtime/handlers/rust.ts
+++ b/packages/sst/src/runtime/handlers/rust.ts
@@ -78,8 +78,10 @@ export const useRustHandler = Context.memo(async () => {
             path.join(input.out, "handler")
           );
         } catch (ex) {
-          console.log(ex);
-          throw new VisibleError("Failed to build");
+          return {
+            type: "error",
+            errors: [String(ex)],
+          };
         }
       }
 
@@ -96,8 +98,10 @@ export const useRustHandler = Context.memo(async () => {
             path.join(input.out, "bootstrap")
           );
         } catch (ex) {
-          console.log(ex);
-          throw new VisibleError("Failed to build");
+          return {
+            type: "error",
+            errors: [String(ex)],
+          };
         }
       }
 


### PR DESCRIPTION
If a build in Rust fails there is no other way to debug. This makes debugging of the issues very hard!
<img width="1105" alt="image" src="https://github.com/serverless-stack/sst/assets/58164/0e873b94-a0bb-411e-a2de-4ae77ccc0a70">
