### PR TITLE
fix: grant migration function permission to decrypt custom secret encryption key

### DIFF
--- a/.changeset/dirty-grapes-knock.md
+++ b/.changeset/dirty-grapes-knock.md
@@ -1,5 +1,5 @@
 ---
-"sst": minor
+"sst": patch
 ---
 
-fix: grant migration function permission to decrypt custom secret encryption key
+RDS: grant migration function permission to decrypt custom secret encryption key

--- a/.changeset/dirty-grapes-knock.md
+++ b/.changeset/dirty-grapes-knock.md
@@ -1,0 +1,5 @@
+---
+"sst": minor
+---
+
+fix: grant migration function permission to decrypt custom secret encryption key

--- a/packages/sst/src/constructs/util/permission.ts
+++ b/packages/sst/src/constructs/util/permission.ts
@@ -283,6 +283,14 @@ function permissionsToStatementsAndGrants(
             [secret.secretArn]
           )
         );
+	if (secret.encryptionKey) {
+          statements.push(
+            buildPolicyStatement(
+              ["kms:Decrypt"],
+              [secret.encryptionKey.keyArn]
+            )
+          );
+	}
       }
     }
     ////////////////////////////////////

--- a/packages/sst/src/constructs/util/permission.ts
+++ b/packages/sst/src/constructs/util/permission.ts
@@ -283,14 +283,11 @@ function permissionsToStatementsAndGrants(
             [secret.secretArn]
           )
         );
-	if (secret.encryptionKey) {
-          statements.push(
-            buildPolicyStatement(
-              ["kms:Decrypt"],
-              [secret.encryptionKey.keyArn]
-            )
-          );
-	}
+      }
+      if (secret?.encryptionKey) {
+        statements.push(
+          buildPolicyStatement(["kms:Decrypt"], [secret.encryptionKey.keyArn])
+        );
       }
     }
     ////////////////////////////////////

--- a/packages/sst/test/constructs/RDS.test.ts
+++ b/packages/sst/test/constructs/RDS.test.ts
@@ -460,7 +460,7 @@ test("cdk.cluster.credentials: using secret name", async () => {
 
 test("cdk.cluster.credentials: using custom kms key", async () => {
   const stack = new Stack(await createApp(), "stack");
-  const key = new kms.Key(stack, "Key")
+  const key = new kms.Key(stack, "Key");
   const cluster = new RDS(stack, "Cluster", {
     engine: "postgresql11.13",
     defaultDatabaseName: "acme",
@@ -470,31 +470,32 @@ test("cdk.cluster.credentials: using custom kms key", async () => {
         credentials: {
           username: "root",
           secretName: "root-secret",
-	  encryptionKey: key,
+          encryptionKey: key,
         },
       },
     },
   });
-  // KMS permissions are granted with custom key
+  // KMS permissions is granted
   const bindings = cluster.getFunctionBinding();
   expect(bindings.permissions["kms:Decrypt"]).toBeDefined();
-  // And migration function has access to this key too
+  // Migration function has permission to this key
   hasResource(stack, "AWS::IAM::Policy", {
     PolicyDocument: {
-      Statement: Match.arrayWith([{
-	Action: "kms:Decrypt",
-	Effect: "Allow",
-	Resource: {
-          "Fn::GetAtt": [
-            "Key961B73FD",
-            "Arn"
-          ],
-	},
-      }]),
+      Statement: Match.arrayWith([
+        {
+          Action: "kms:Decrypt",
+          Effect: "Allow",
+          Resource: {
+            "Fn::GetAtt": ["Key961B73FD", "Arn"],
+          },
+        },
+      ]),
     },
-    Roles: [{
-      Ref: "ClusterMigrationFunctionServiceRole720A9F55"
-    }]
+    Roles: [
+      {
+        Ref: "ClusterMigrationFunctionServiceRole720A9F55",
+      },
+    ],
   });
 });
 

--- a/packages/sst/test/constructs/RDS.test.ts
+++ b/packages/sst/test/constructs/RDS.test.ts
@@ -7,7 +7,7 @@ import * as ec2 from "aws-cdk-lib/aws-ec2";
 import * as rds from "aws-cdk-lib/aws-rds";
 import * as secretsManager from "aws-cdk-lib/aws-secretsmanager";
 import * as kms from "aws-cdk-lib/aws-kms";
-import { Template } from "aws-cdk-lib/assertions";
+import { Match } from "aws-cdk-lib/assertions";
 import { App, Stack, RDS, RDSProps } from "../../dist/constructs/";
 
 /////////////////////////////
@@ -456,6 +456,46 @@ test("cdk.cluster.credentials: using secret name", async () => {
   // KMS permissions is not granted (not necessary b/c not using custom KMS key)
   const bindings = cluster.getFunctionBinding();
   expect(bindings.permissions["kms:Decrypt"]).toBeUndefined();
+});
+
+test("cdk.cluster.credentials: using custom kms key", async () => {
+  const stack = new Stack(await createApp(), "stack");
+  const key = new kms.Key(stack, "Key")
+  const cluster = new RDS(stack, "Cluster", {
+    engine: "postgresql11.13",
+    defaultDatabaseName: "acme",
+    migrations: "test/constructs/migrations",
+    cdk: {
+      cluster: {
+        credentials: {
+          username: "root",
+          secretName: "root-secret",
+	  encryptionKey: key,
+        },
+      },
+    },
+  });
+  // KMS permissions are granted with custom key
+  const bindings = cluster.getFunctionBinding();
+  expect(bindings.permissions["kms:Decrypt"]).toBeDefined();
+  // And migration function has access to this key too
+  hasResource(stack, "AWS::IAM::Policy", {
+    PolicyDocument: {
+      Statement: Match.arrayWith([{
+	Action: "kms:Decrypt",
+	Effect: "Allow",
+	Resource: {
+          "Fn::GetAtt": [
+            "Key961B73FD",
+            "Arn"
+          ],
+	},
+      }]),
+    },
+    Roles: [{
+      Ref: "ClusterMigrationFunctionServiceRole720A9F55"
+    }]
+  });
 });
 
 test("cdk.cluster.credentials: imported secret with custom encryption key", async () => {


### PR DESCRIPTION
This is related to #3035. If you use migrations, the migration function should also be able to decrypt the key.

BTW, this permissions thing looks very complex, instead of `secret.grantRead()` it becomes a whole different ball game.