### PR TITLE
feat: run only one gradle build per java directory

### DIFF
--- a/.changeset/early-cameras-leave.md
+++ b/.changeset/early-cameras-leave.md
@@ -1,5 +1,5 @@
 ---
-"sst": minor
+"sst": patch
 ---
 
-feat: run only one gradle build per java directory
+Function/java: run only one gradle build per directory

--- a/.changeset/early-cameras-leave.md
+++ b/.changeset/early-cameras-leave.md
@@ -1,0 +1,5 @@
+---
+"sst": minor
+---
+
+feat: run only one gradle build per java directory

--- a/packages/sst/src/runtime/handlers/java.ts
+++ b/packages/sst/src/runtime/handlers/java.ts
@@ -18,8 +18,7 @@ export const useJavaHandler = Context.memo(async () => {
   const handlers = useRuntimeHandlers();
   const processes = new Map<string, ChildProcessWithoutNullStreams>();
   const sources = new Map<string, string>();
-  const runningBuilds = new Map<string, ReturnType<typeof execAsync>>();
-  const zippedBuilds = new Map<string, boolean>();
+  const runningBuilds = new Map<string, Promise<void>>();
 
   handlers.register({
     shouldBuild: (input) => {
@@ -76,13 +75,9 @@ export const useJavaHandler = Context.memo(async () => {
       const outputDir = input.props.java?.buildOutputDir || "distributions";
       sources.set(input.functionID, srcPath);
 
-      // Run gradle build once per directory. Otherwise they'll interfere
-      // with one another.
-      async function buildOnce() {
-        let runningBuild = runningBuilds.get(buildBinary);
-        if (runningBuild) return runningBuild;
-
-        runningBuild = execAsync(
+      async function build() {
+        // build
+        await execAsync(
           `${buildBinary} ${buildTask} -Dorg.gradle.logging.level=${
             process.env.DEBUG ? "debug" : "lifecycle"
           }`,
@@ -90,25 +85,28 @@ export const useJavaHandler = Context.memo(async () => {
             cwd: srcPath,
           }
         );
-        runningBuilds.set(buildBinary, runningBuild);
-        return runningBuild;
-      }
 
-      // Similarly only zip once per directory
-      async function zipOnce() {
-        if (zippedBuilds.get(buildBinary)) return;
-
+        // unzip
         const buildOutput = path.join(srcPath, "build", outputDir);
         const zip = (await fs.readdir(buildOutput)).find((f) =>
           f.endsWith(".zip")
         )!;
-        new AdmZip(path.join(buildOutput, zip)).extractAllTo(input.out);
-        zippedBuilds.set(buildBinary, true);
+        await new Promise((resolve, reject) => {
+          const zipper = new AdmZip(path.join(buildOutput, zip));
+          zipper.extractAllToAsync(input.out, false, false, (err) =>
+            err ? reject(err) : resolve(undefined)
+          );
+        });
       }
 
       try {
-        await buildOnce();
-        await zipOnce();
+        // Run gradle build once per directory. Otherwise they'll interfere
+        // with one another
+        const buildPromise = runningBuilds.get(buildBinary) ?? build();
+        runningBuilds.set(buildBinary, buildPromise);
+        await buildPromise;
+        runningBuilds.delete(buildBinary);
+
         return {
           type: "success",
           handler: input.props.handler!,

--- a/packages/sst/src/runtime/handlers/java.ts
+++ b/packages/sst/src/runtime/handlers/java.ts
@@ -94,6 +94,7 @@ export const useJavaHandler = Context.memo(async () => {
             f.endsWith(".zip")
           )!;
           new AdmZip(path.join(buildOutput, zip)).extractAllTo(input.out);
+	  zippedBuilds[buildBinary] = true;
 	}
         return {
           type: "success",


### PR DESCRIPTION
Currently a gradle build job is started for every Function even if it points to the same directory, causing massive machine load and build errors.

This could still start two builds, but only in succession. Ideally there's some mop up logic in the parent so it starts builds only once. But this is probably good enough for most scenarios.

Instead of `gradlew` ideally I would have the ability to run a `gradle:build` or so if one is defined in `package.json`. The idea here is to make sure gradle does not write output to the project directory, as that is annoying in monorepo projects. So would need to specify `--project-output-path` I believe.

But that might be another PR, this already greatly improves our builds.