### PR TITLE
Feat/boundary policy sst bootstrap

### DIFF
--- a/.changeset/cuddly-trainers-happen.md
+++ b/.changeset/cuddly-trainers-happen.md
@@ -3,4 +3,4 @@
 "@serverless-stack/docs": patch
 ---
 
-bootstrap: support custom permissions boundary
+Bootstrap: support custom permissions boundary

--- a/.changeset/cuddly-trainers-happen.md
+++ b/.changeset/cuddly-trainers-happen.md
@@ -1,0 +1,6 @@
+---
+"sst": patch
+"@serverless-stack/docs": patch
+---
+
+bootstrap: support custom permissions boundary

--- a/packages/sst/src/bootstrap.ts
+++ b/packages/sst/src/bootstrap.ts
@@ -274,13 +274,14 @@ export async function bootstrapSST() {
   });
   rule.addTarget(new LambdaFunction(fn));
 
+  // Create permissions boundary
   if (cdk?.customPermissionsBoundary) {
-    const permBoundary = ManagedPolicy.fromManagedPolicyName(
+    const boundaryPolicy = ManagedPolicy.fromManagedPolicyName(
       stack,
-      stack.stackId,
+      "PermissionBoundaryPolicy",
       cdk.customPermissionsBoundary
     );
-    PermissionsBoundary.of(stack).apply(permBoundary);
+    PermissionsBoundary.of(stack).apply(boundaryPolicy);
   }
 
   // Create stack outputs to store bootstrap stack info

--- a/packages/sst/src/bootstrap.ts
+++ b/packages/sst/src/bootstrap.ts
@@ -16,7 +16,11 @@ import {
   RemovalPolicy,
 } from "aws-cdk-lib/core";
 import { Function, Runtime, Code } from "aws-cdk-lib/aws-lambda";
-import { PolicyStatement } from "aws-cdk-lib/aws-iam";
+import {
+  ManagedPolicy,
+  PermissionsBoundary,
+  PolicyStatement,
+} from "aws-cdk-lib/aws-iam";
 import { Rule } from "aws-cdk-lib/aws-events";
 import { LambdaFunction } from "aws-cdk-lib/aws-events-targets";
 import {
@@ -269,6 +273,15 @@ export async function bootstrapSST() {
     },
   });
   rule.addTarget(new LambdaFunction(fn));
+
+  if (cdk?.customPermissionsBoundary) {
+    const permBoundary = ManagedPolicy.fromManagedPolicyName(
+      stack,
+      stack.stackId,
+      cdk.customPermissionsBoundary
+    );
+    PermissionsBoundary.of(stack).apply(permBoundary);
+  }
 
   // Create stack outputs to store bootstrap stack info
   new CfnOutput(stack, OUTPUT_VERSION, { value: LATEST_VERSION });

--- a/www/docs/configuring-sst.md
+++ b/www/docs/configuring-sst.md
@@ -81,21 +81,21 @@ Here's the full list of config options that can be returned:
 - **`ssmPrefix`** SSM prefix for all SSM parameters that SST creates
 - **`advanced`**
   - **`disableParameterizedStackNameCheck`** Disable the check for stack names to be parameterized with the stage name.
-- **`cdk`**
-  - **`qualifier`** The qualifier for the CDK toolkit stack
-  - **`pathMetadata`** Add CDK path metadata to templates. This enables the CDK Construct tree view in the CloudFormation console. Default `false`.
-  - **`deployRoleArn`**: IAM role used to initiate a deployment
-  - **`lookupRoleArn`** IAM role used to look up values from the AWS account
-  - **`toolkitStackName`** The name of the CDK toolkit stack
-  - **`fileAssetsBucketName`** The name of the CDK toolkit bucket
-  - **`fileAssetPublishingRoleArn`** IAM role used to publish file assets to the S3 bucket
-  - **`imageAssetPublishingRoleArn`** IAM role used to publish image assets to the ECR repository
-  - **`cloudFormationExecutionRole`** IAM role assumed by the CloudFormation to deploy
-  - **`publicAccessBlockConfiguration`** Block public access configuration on the CDK toolkit bucket
 - **`bootstrap`**
-  - **`tags`** Tags to use for the bootstrap stack
-  - **`stackName`** The name to use for the bootstrap stack
-  - **`customPermissionsBoundary`** The Name of the IAM permissions boundary policy to use for the CDK toolkit stack and SST Bootstrap stack
+  - **`stackName`** The name to use for the SST bootstrap stack
+  - **`tags`** Tags to use for the SST bootstrap stack
+- **`cdk`**
+  - **`cloudFormationExecutionRole`** IAM role assumed by the CloudFormation to deploy
+  - **`customPermissionsBoundary`** The Name of the IAM permissions boundary policy to use for the CDK toolkit stack and SST bootstrap stack
+  - **`deployRoleArn`**: IAM role used to initiate a deployment
+  - **`fileAssetPublishingRoleArn`** IAM role used to publish file assets to the S3 bucket
+  - **`fileAssetsBucketName`** The name of the CDK toolkit bucket
+  - **`imageAssetPublishingRoleArn`** IAM role used to publish image assets to the ECR repository
+  - **`lookupRoleArn`** IAM role used to look up values from the AWS account
+  - **`pathMetadata`** Add CDK path metadata to templates. This enables the CDK Construct tree view in the CloudFormation console. Default `false`.
+  - **`publicAccessBlockConfiguration`** Block public access configuration on the CDK toolkit bucket and SST bootstrap bucket
+  - **`qualifier`** The qualifier for the CDK toolkit stack
+  - **`toolkitStackName`** The name of the CDK toolkit stack
 
 \*These won't take effect if the CLI flag for it is specified.
 

--- a/www/docs/configuring-sst.md
+++ b/www/docs/configuring-sst.md
@@ -95,6 +95,7 @@ Here's the full list of config options that can be returned:
 - **`bootstrap`**
   - **`tags`** Tags to use for the bootstrap stack
   - **`stackName`** The name to use for the bootstrap stack
+  - **`customPermissionsBoundary`** The Name of the IAM permissions boundary policy to use for the CDK toolkit stack and SST Bootstrap stack
 
 \*These won't take effect if the CLI flag for it is specified.
 


### PR DESCRIPTION
This is intended to fix issue #3105.

Extend the custom permissions boundary to apply to both the cdk and sst bootstrap stacks.