### PR TITLE
fix: SsrFunction with id ServerFunction already exists

### DIFF
--- a/packages/sst/src/constructs/NextjsSite.ts
+++ b/packages/sst/src/constructs/NextjsSite.ts
@@ -145,7 +145,7 @@ export class NextjsSite extends SsrSite {
       environment,
       cdk,
     } = this.props;
-    return new SsrFunction(this, `ServerFunction`, {
+    return new SsrFunction(this, `ServerFunctionRegional`, {
       description: "Next.js server",
       bundle: path.join(this.props.path, ".open-next", "server-function"),
       handler: "index.handler",
@@ -167,7 +167,7 @@ export class NextjsSite extends SsrSite {
   protected createFunctionForEdge() {
     const { runtime, timeout, memorySize, bind, permissions, environment } =
       this.props;
-    return new EdgeFunction(this, "ServerFunction", {
+    return new EdgeFunction(this, "ServerFunctionEdge", {
       bundle: path.join(this.props.path, ".open-next", "server-function"),
       handler: "index.handler",
       runtime,


### PR DESCRIPTION
Starting with sst version 2.19.2 using NextjsSite construct failed to deploy with the error:

Trace: Error: SsrFunction with id "ServerFunction" already exists.

changing the ids in the construct fixes the issue, the weird thing is that theoretically only regional or edge should be used at once and not both but I'm not sure why the function that checks for duplicate ids sees both.

Note the error started appearing with 2.19.2 because it adds the id and metadata to SsrFunction construct