### PR TITLE
Function: Add support for cgo and ldflags for go runtime

### DIFF
--- a/packages/sst/src/constructs/Function.ts
+++ b/packages/sst/src/constructs/Function.ts
@@ -127,6 +127,11 @@ export interface FunctionProps
   copyFiles?: FunctionCopyFilesProps[];
 
   /**
+   * Used to configure go function properties
+   */
+  go?: GoProps;
+
+  /**
    * Used to configure nodejs function properties
    */
   nodejs?: NodeJSProps;
@@ -532,6 +537,34 @@ export interface PythonProps {
    * ```
    */
   installCommands?: string[];
+}
+
+/**
+ * Used to configure Go bundling options
+ */
+export interface GoProps {
+  /**
+   * The ldflags to use when building the Go module.
+   *
+   * @default "['-s', '-w']"
+   */
+  ldFlags?: string[];
+
+  /**
+   * Whether to enable CGO for the Go build.
+   *
+   * @default false
+   *
+   * @example
+   * ```js
+   * new Function(stack, "Function", {
+   *   go: {
+   *     cgoEnabled: true,
+   *   }
+   * })
+   * ```
+   */
+  cgoEnabled?: boolean;
 }
 
 /**

--- a/packages/sst/src/runtime/handlers/go.ts
+++ b/packages/sst/src/runtime/handlers/go.ts
@@ -59,13 +59,17 @@ export const useGoHandler = Context.memo(async () => {
       sources.set(input.functionID, project);
       const src = path.relative(project, input.props.handler!);
 
+      const ldFlags = input.props.go?.ldFlags || ["-s", "-w"];
+
       if (input.mode === "start") {
         try {
           const target = path.join(input.out, handlerName);
           const srcPath =
             os.platform() === "win32" ? src.replaceAll("\\", "\\\\") : src;
           const result = await execAsync(
-            `go build -ldflags "-s -w" -o "${target}" ./${srcPath}`,
+            `go build -ldflags "${ldFlags.join(
+              " "
+            )}" -o "${target}" ./${srcPath}`,
             {
               cwd: project,
               env: {
@@ -87,12 +91,14 @@ export const useGoHandler = Context.memo(async () => {
           const srcPath =
             os.platform() === "win32" ? src.replaceAll("\\", "\\\\") : src;
           await execAsync(
-            `go build -ldflags "-s -w" -o "${target}" ./${srcPath}`,
+            `go build -ldflags "${ldFlags.join(
+              " "
+            )}" -o "${target}" ./${srcPath}`,
             {
               cwd: project,
               env: {
                 ...process.env,
-                CGO_ENABLED: "0",
+                CGO_ENABLED: input.props.go?.cgoEnabled ? "1" : "0",
                 GOARCH:
                   input.props.architecture === "arm_64" ? "arm64" : "amd64",
                 GOOS: "linux",


### PR DESCRIPTION
Fixes #3097.

This commit adds a configurable ldflags & cgo to go handler functions.