### PR TITLE
console: fix rendering sets in DynamoDB table view.

### DIFF
--- a/packages/console/src/App/Stage/Dynamo/index.tsx
+++ b/packages/console/src/App/Stage/Dynamo/index.tsx
@@ -428,10 +428,15 @@ function renderValue(val: any): string {
     case "object":
       if (ArrayBuffer.isView(val))
         return "Binary: " + Buffer.from(val as any).toString("base64");
-      return JSON.stringify(val, null, 2);
+      return JSON.stringify(val, replacer, 2);
     case "undefined":
       return "<null>";
     default:
       return "<unknown>";
   }
+}
+
+function replacer(_k: string, val: unknown) {
+  if (val instanceof Set) return Array.from(val);
+  return val;
 }


### PR DESCRIPTION
DyanmoDB sets are currently rendered as an empty object `{}` in the console. I've added a replacer function to convert them to an array before stringifying. 

Note: this only addresses rendering sets in the table view. The DynamoDB editor is a whole different story since converting it to an array there would change the data type to a DynamoDB List after saving.

