### PR TITLE
Delete side effect only @aws-sdk/types import

### DIFF
--- a/packages/sst/src/credentials.ts
+++ b/packages/sst/src/credentials.ts
@@ -1,4 +1,3 @@
-import "@aws-sdk/types";
 import { Context } from "./context/context.js";
 import { fromNodeProviderChain } from "@aws-sdk/credential-providers";
 import { Client } from "@aws-sdk/smithy-client";


### PR DESCRIPTION
"Bare" imports that don't name what they are importing are never elided by Typescript and end up in the compiled JS. That doesn't make any sense for this package since it only has types.

I don't know why this was originally added, but it still typechecks without it now so I don't think it's necessary.

Partial fix for #3140 