### PR TITLE
fix: add next-url to NextjsSite header

### DIFF
--- a/.changeset/ten-pandas-smash.md
+++ b/.changeset/ten-pandas-smash.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+NextjsSite: add `next-url` to cache policy

--- a/packages/sst/src/constructs/NextjsSite.ts
+++ b/packages/sst/src/constructs/NextjsSite.ts
@@ -351,6 +351,7 @@ export class NextjsSite extends SsrSite {
         "rsc",
         "next-router-prefetch",
         "next-router-state-tree",
+        "next-url",
       ]);
     const serverBehavior = this.buildDefaultBehaviorForRegional(cachePolicy);
 


### PR DESCRIPTION
As of next 13.4.13+, Nextjs has added `next-url` to the vary headers. https://github.com/vercel/next.js/blob/canary/packages/next/src/client/components/app-router-headers.ts#L10