### PR TITLE
Function: Add policy statement resource for Function to access bootstrap bucket objects during live debugging.

### DIFF
--- a/.changeset/modern-buckets-switch.md
+++ b/.changeset/modern-buckets-switch.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+Function: Add policy statement resource for Function to access bootstrap bucket objects during live debugging.

--- a/packages/sst/src/constructs/Function.ts
+++ b/packages/sst/src/constructs/Function.ts
@@ -803,6 +803,7 @@ export class Function extends CDKFunction implements SSTConstruct {
       this.addEnvironment("SST_FUNCTION_ID", this.node.addr);
       useDeferredTasks().add(async () => {
         const bootstrap = await useBootstrap();
+        const bootstrapBucketArn = `arn:${Stack.of(this).partition}:s3:::${bootstrap.bucket}`;
         this.attachPermissions([
           new PolicyStatement({
             actions: ["iot:*"],
@@ -813,7 +814,8 @@ export class Function extends CDKFunction implements SSTConstruct {
             actions: ["s3:*"],
             effect: Effect.ALLOW,
             resources: [
-              `arn:${Stack.of(this).partition}:s3:::${bootstrap.bucket}`,
+              bootstrapBucketArn,
+              `${bootstrapBucketArn}/*`,
             ],
           }),
         ]);


### PR DESCRIPTION
Currently the Function construct, when live debugging, uploads to bootstrap bucket instead of using IoT if the payload is above 3MB. The policy statement, however, for the function only allows `s3:*` for the **bucket**, but not the **objects** within. This PR adds the additional wildcard resource for the objects contained within the bucket.

Note: It may be prudent to implement a more specific resource such as `<arn>/pointers/*` instead of the broad wildcard I have used here, but I will leave that up to your discretion.

Relevant lines in `iot.ts` where this PutObjectCommand is currently failing:
https://github.com/serverless-stack/sst/blob/b56c2ea021290211c72841c605cec58579ef3591/packages/sst/src/iot.ts#L49-L58