### PR TITLE
fix: refactor duplicate code; set next-url for edge

### DIFF
--- a/.changeset/unlucky-files-count.md
+++ b/.changeset/unlucky-files-count.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+NextjsSite: add "next-url" to allowed headers

--- a/packages/sst/src/constructs/NextjsSite.ts
+++ b/packages/sst/src/constructs/NextjsSite.ts
@@ -291,6 +291,20 @@ export class NextjsSite extends SsrSite {
     resource.node.addDependency(policy);
   }
 
+  private getCachePolicy() {
+    const { cdk } = this.props;
+    const cachePolicy =
+      cdk?.serverCachePolicy ??
+      this.buildServerCachePolicy([
+        "accept",
+        "rsc",
+        "next-router-prefetch",
+        "next-router-state-tree",
+        "next-url",
+      ]);
+    return cachePolicy;
+  }
+
   protected createCloudFrontDistributionForRegional(): Distribution {
     /**
      * Next.js requests
@@ -344,15 +358,7 @@ export class NextjsSite extends SsrSite {
 
     const { cdk } = this.props;
     const cfDistributionProps = cdk?.distribution || {};
-    const cachePolicy =
-      cdk?.serverCachePolicy ??
-      this.buildServerCachePolicy([
-        "accept",
-        "rsc",
-        "next-router-prefetch",
-        "next-router-state-tree",
-        "next-url",
-      ]);
+    const cachePolicy = this.getCachePolicy();
     const serverBehavior = this.buildDefaultBehaviorForRegional(cachePolicy);
 
     return new Distribution(this, "Distribution", {
@@ -376,14 +382,7 @@ export class NextjsSite extends SsrSite {
   protected createCloudFrontDistributionForEdge(): Distribution {
     const { cdk } = this.props;
     const cfDistributionProps = cdk?.distribution || {};
-    const cachePolicy =
-      cdk?.serverCachePolicy ??
-      this.buildServerCachePolicy([
-        "accept",
-        "rsc",
-        "next-router-prefetch",
-        "next-router-state-tree",
-      ]);
+    const cachePolicy = this.getCachePolicy();
     const serverBehavior = this.buildDefaultBehaviorForEdge(cachePolicy);
 
     return new Distribution(this, "Distribution", {

--- a/packages/sst/src/constructs/NextjsSite.ts
+++ b/packages/sst/src/constructs/NextjsSite.ts
@@ -291,18 +291,14 @@ export class NextjsSite extends SsrSite {
     resource.node.addDependency(policy);
   }
 
-  private getCachePolicy() {
-    const { cdk } = this.props;
-    const cachePolicy =
-      cdk?.serverCachePolicy ??
-      this.buildServerCachePolicy([
-        "accept",
-        "rsc",
-        "next-router-prefetch",
-        "next-router-state-tree",
-        "next-url",
-      ]);
-    return cachePolicy;
+  protected buildServerCachePolicy() {
+    return super.buildServerCachePolicy([
+      "accept",
+      "rsc",
+      "next-router-prefetch",
+      "next-router-state-tree",
+      "next-url",
+    ]);
   }
 
   protected createCloudFrontDistributionForRegional(): Distribution {
@@ -358,7 +354,7 @@ export class NextjsSite extends SsrSite {
 
     const { cdk } = this.props;
     const cfDistributionProps = cdk?.distribution || {};
-    const cachePolicy = this.getCachePolicy();
+    const cachePolicy = cdk?.serverCachePolicy ?? this.buildServerCachePolicy();
     const serverBehavior = this.buildDefaultBehaviorForRegional(cachePolicy);
 
     return new Distribution(this, "Distribution", {
@@ -382,7 +378,7 @@ export class NextjsSite extends SsrSite {
   protected createCloudFrontDistributionForEdge(): Distribution {
     const { cdk } = this.props;
     const cfDistributionProps = cdk?.distribution || {};
-    const cachePolicy = this.getCachePolicy();
+    const cachePolicy = cdk?.serverCachePolicy ?? this.buildServerCachePolicy();
     const serverBehavior = this.buildDefaultBehaviorForEdge(cachePolicy);
 
     return new Distribution(this, "Distribution", {


### PR DESCRIPTION
I forgot to set `next-url` for edge mode. Refactored duplicate methods to reduce similar mistakes.