### PR TITLE
fix: dispose of esbuild context when in deploy mode

### DIFF
--- a/.changeset/warm-pants-crash.md
+++ b/.changeset/warm-pants-crash.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+fix: dispose of esbuild context when in deploy mode

--- a/packages/sst/src/runtime/handlers/node.ts
+++ b/packages/sst/src/runtime/handlers/node.ts
@@ -279,6 +279,10 @@ export const useNodeHandler = Context.memo(async () => {
           rebuildCache[input.functionID] = { ctx, result };
         }
 
+        if (input.mode === "deploy") {
+          ctx.dispose();
+        }
+
         logMemoryUsage(input.functionID, input.props.handler!);
 
         return {


### PR DESCRIPTION
https://discord.com/channels/983865673656705025/1136428086531997797

Deadlock errors occurring again during build since this change https://github.com/serverless-stack/sst/commit/ba2156ff74b8a8e3d48ea243f17a743c2b134502 now means ctx is no longer stored in cache when running in deploy mode, and so is not cleaned up properly on exit.

