### PR TITLE
fix: respect newline char when writing package.json

### DIFF
--- a/.changeset/thin-cheetahs-sit.md
+++ b/.changeset/thin-cheetahs-sit.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+sst update: respect trailing newline char in package.json


### PR DESCRIPTION
RE: https://discord.com/channels/983865673656705025/1007139657324187729/1135930483851673673

Just a small change to respect the newline chars when overwriting `package.json`s during `sst update` - works when there is a newline and when there isn't one