### PR TITLE
EventBus: pass attempts count to EventHandler callback

### DIFF
--- a/.changeset/three-gifts-jam.md
+++ b/.changeset/three-gifts-jam.md
@@ -1,0 +1,5 @@
+---
+"sst": patch
+---
+
+EventBus: pass attempts count to EventHandler callback

--- a/packages/sst/src/node/event-bus/index.ts
+++ b/packages/sst/src/node/event-bus/index.ts
@@ -99,6 +99,7 @@ type EventPayload<E extends Event> = {
   metadata: undefined extends E["shape"]["metadata"]
     ? E["shape"]["metadataFn"]
     : E["shape"]["metadata"];
+  attempts: number;
 };
 
 export function EventHandler<Events extends Event>(
@@ -109,11 +110,14 @@ export function EventHandler<Events extends Event>(
     }[Events["type"]]
   ) => Promise<void>
 ) {
-  return async (event: EventBridgeEvent<string, any>) => {
+  return async (
+    event: EventBridgeEvent<string, any> & { attempts?: number }
+  ) => {
     await cb({
       type: event["detail-type"],
       properties: event.detail.properties,
       metadata: event.detail.metadata,
+      attempts: event.attempts ?? 0,
     });
   };
 }


### PR DESCRIPTION
This PR makes the EventHandler helper pass attempts count further to the callback. It's set on the event in the retrier logic.

Per Discord topic: https://discord.com/channels/983865673656705025/1132162244973699146 

I'm also not 100% sure about the changesets stuff, feel free to let me know if something is off 😃