### PR TITLE
fix: docs for Service Dockerfile

### DIFF
--- a/www/docs/constructs/Service.about.md
+++ b/www/docs/constructs/Service.about.md
@@ -25,9 +25,10 @@ Here's an example of the `Dockerfile` for a simple Express app.
 FROM node:18-bullseye-slim
 
 COPY . /app
-RUN npm install
 
 WORKDIR /app/
+RUN npm install
+
 ENTRYPOINT ["node", "app.mjs"]
 ```
 

--- a/www/docs/constructs/Service.about.md
+++ b/www/docs/constructs/Service.about.md
@@ -25,8 +25,8 @@ Here's an example of the `Dockerfile` for a simple Express app.
 FROM node:18-bullseye-slim
 
 COPY . /app
-
 WORKDIR /app/
+
 RUN npm install
 
 ENTRYPOINT ["node", "app.mjs"]


### PR DESCRIPTION
Small issue with the Service docs related to the Dockerfile:
Need to be in the WORKDIR where package.json is to run rpm install.